### PR TITLE
Fixes Issue #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Controller.properties Object
 
 #### Set the Clock of the Controller
 
-**NOTE** `Controller.prototype.readWallClock` and `Controller.prototype.writeWallClock` are not currently supported by **CompactLogix** controllers.
+**NOTE** `Controller.prototype.readWallClock` and `Controller.prototype.writeWallClock` are experimental features and may not be available on all controllers. 1756-L8 ControlLogix Controllers are currently the only PLCs supporting these features.
 
 Sync Controller WallClock to PC Datetime
 

--- a/src/controller/index.js
+++ b/src/controller/index.js
@@ -122,9 +122,6 @@ class Controller extends ENIP {
 
         // Fetch Controller Properties and Wall Clock
         await this.readControllerProps();
-
-        const cntType = this.state.controller.name.split("-")[0];
-        if (cntType === "1756") await this.readWallClock();
     }
 
     /**
@@ -222,9 +219,8 @@ class Controller extends ENIP {
      * @returns {Promise}
      */
     async readWallClock() {
-        const cntType = this.state.controller.name.split("-")[0];
-        if (cntType === "1769")
-            throw new Error("WallClock Utilities are not supported by CompactLogix");
+        if (this.state.controller.name.search("L8") === -1)
+            throw new Error("WallClock Utilities are not supported by this controller type");
 
         const { GET_ATTRIBUTE_SINGLE } = CIP.MessageRouter.services;
         const { LOGICAL } = CIP.EPATH.segments;
@@ -279,9 +275,8 @@ class Controller extends ENIP {
      * @returns {Promise}
      */
     async writeWallClock(date = new Date()) {
-        const cntType = this.state.controller.name.split("-")[0];
-        if (cntType === "1769")
-            throw new Error("WallClock Utilities are not supported by CompactLogix");
+        if (this.state.controller.name.search("L8") === -1)
+            throw new Error("WallClock Utilities are not supported by this controller type");
 
         const { SET_ATTRIBUTE_SINGLE } = CIP.MessageRouter.services;
         const { LOGICAL } = CIP.EPATH.segments;


### PR DESCRIPTION
- Adds regex to check for L8 controller in readWallClock() and writeWallClock() (only known, tested controller to support WallClock Utilities)
- Updates README.md to reflect WallClock Utilities being experimental

### Description, Motivation, and Context

The only PLC's tested with support of the WallClock Utilities are the L8 PLCs. Attempting to connect to a ControlLogix L7 processor would fail on the `readWallClock` function.

## How Has This Been Tested?

- `npm run test:local` completes succesfully
- functional test reading PLC properties from 1769-L19 PLC.


## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This is a work in progress, and I want some feedback (If yes, please mark it in the title -> e.g. `[WIP] Some awesome PR title`)

## Related Issue

This is related to #1.
