### PR TITLE
Allows leading underscore in tag names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ethernet-ip",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "A simple node interface for Ethernet/IP.",
     "main": "./src/index.js",
     "scripts": {

--- a/src/tag/index.js
+++ b/src/tag/index.js
@@ -404,7 +404,7 @@ class Tag extends EventEmitter {
         const tag = tagname.split(".");
 
         const test = tag[tag.length - 1];
-        const regex = /^[a-zA-Z][a-zA-Z0-9_]*([a-zA-Z0-9_]|\[\d+\])$/i; // regex string to check for valid tagnames
+        const regex = /^[a-zA-Z_][a-zA-Z0-9_]*([a-zA-Z0-9_]|\[\d+\])$/i; // regex string to check for valid tagnames
         return typeof tagname === "string" && regex.test(test) && test.length <= 40;
     }
     // endregion

--- a/src/tag/tag.spec.js
+++ b/src/tag/tag.spec.js
@@ -20,7 +20,7 @@ describe("Tag Class", () => {
         it("Accepts and Rejects Appropriate Inputs", () => {
             const fn = test => Tag.isValidTagname(test);
 
-            expect(fn("_sometagname")).toBeFalsy();
+            expect(fn("_sometagname")).toBeTruthy();
             expect(fn(12345)).toBeFalsy();
             expect(fn(null)).toBeFalsy();
             expect(fn(undefined)).toBeFalsy();
@@ -63,7 +63,7 @@ describe("Tag Class", () => {
             const tag3 = new Tag("tag", null, Types.REAL);
             const tag4 = new Tag("tag", null, Types.SINT);
             const tag5 = new Tag("tag", null, Types.INT);
-            
+
             expect(tag1.generateWriteMessageRequest(100)).toMatchSnapshot();
             expect(tag2.generateWriteMessageRequest(true)).toMatchSnapshot();
             expect(tag3.generateWriteMessageRequest(32.1234)).toMatchSnapshot();


### PR DESCRIPTION
### Description, Motivation, and Context

modifies tag name regex to allow leading underscore in tag names

## How Has This Been Tested?
- functionally tested on PLC with tag "_dt"
- npm run test:local passes

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This is a work in progress, and I want some feedback (If yes, please mark it in the title -> e.g. `[WIP] Some awesome PR title`)

## Related Issue

Fix #9 
