### PR TITLE
Adds the ability to use Fully-Qualified Domain Name for PLC address

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ethernet-ip",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "description": "A simple node interface for Ethernet/IP.",
     "main": "./src/index.js",
     "scripts": {

--- a/src/controller/index.js
+++ b/src/controller/index.js
@@ -102,7 +102,7 @@ class Controller extends ENIP {
      * and Returns a Promise with the Established Session ID
      *
      * @override
-     * @param {string} IP_ADDR - IPv4 Address
+     * @param {string} IP_ADDR - IPv4 Address (can also accept a FQDN, provided port forwarding is configured correctly.)
      * @param {number} SLOT - Controller Slot Number (0 if CompactLogix)
      * @returns {Promise}
      * @memberof ENIP

--- a/src/enip/index.js
+++ b/src/enip/index.js
@@ -3,7 +3,7 @@ const { EIP_PORT } = require("../config");
 const encapsulation = require("./encapsulation");
 const CIP = require("./cip");
 const { promiseTimeout } = require("../utilities");
-const { lookup } = require('dns');
+const { lookup } = require("dns");
 
 /**
  * Low Level Ethernet/IP
@@ -91,15 +91,15 @@ class ENIP extends Socket {
             throw new Error("Controller <class> requires IP_ADDR <string>!!!");
         }
         await new Promise((resolve, reject) => {
-          lookup(IP_ADDR, (err, addr, family) => {
-            if (err)
-              reject(new Error("DNS Lookup failed for IP_ADDR " + IP_ADDR));
+            lookup(IP_ADDR, (err, addr) => {
+                if (err)
+                    reject(new Error("DNS Lookup failed for IP_ADDR " + IP_ADDR));
 
-            if (!isIPv4(addr)) {
-                reject(new Error("Invalid IP_ADDR <string> passed to Controller <class>"));
-            }
-            resolve();
-          });
+                if (!isIPv4(addr)) {
+                    reject(new Error("Invalid IP_ADDR <string> passed to Controller <class>"));
+                }
+                resolve();
+            });
         });
 
         const { registerSession } = encapsulation;

--- a/src/enip/index.js
+++ b/src/enip/index.js
@@ -78,7 +78,7 @@ class ENIP extends Socket {
     // region Public Method Definitions
 
     /**
-     * Initializes Session with Desired IP Address or FQ
+     * Initializes Session with Desired IP Address or FQDN
      * and Returns a Promise with the Established Session ID
      *
      * @override

--- a/src/enip/index.js
+++ b/src/enip/index.js
@@ -3,6 +3,7 @@ const { EIP_PORT } = require("../config");
 const encapsulation = require("./encapsulation");
 const CIP = require("./cip");
 const { promiseTimeout } = require("../utilities");
+const { lookup } = require('dns');
 
 /**
  * Low Level Ethernet/IP
@@ -77,11 +78,11 @@ class ENIP extends Socket {
     // region Public Method Definitions
 
     /**
-     * Initializes Session with Desired IP Address
+     * Initializes Session with Desired IP Address or FQ
      * and Returns a Promise with the Established Session ID
      *
      * @override
-     * @param {string} IP_ADDR - IPv4 Address
+     * @param {string} IP_ADDR - IPv4 Address (can also accept a FQDN, provided port forwarding is configured correctly.)
      * @returns {Promise}
      * @memberof ENIP
      */
@@ -89,10 +90,17 @@ class ENIP extends Socket {
         if (!IP_ADDR) {
             throw new Error("Controller <class> requires IP_ADDR <string>!!!");
         }
+        await new Promise((resolve, reject) => {
+          lookup(IP_ADDR, (err, addr, family) => {
+            if (err)
+              reject(new Error("DNS Lookup failed for IP_ADDR " + IP_ADDR));
 
-        if (!isIPv4(IP_ADDR)) {
-            throw new Error("Invalid IP_ADDR <string> passed to Controller <class>");
-        }
+            if (!isIPv4(addr)) {
+                reject(new Error("Invalid IP_ADDR <string> passed to Controller <class>"));
+            }
+            resolve();
+          });
+        });
 
         const { registerSession } = encapsulation;
 


### PR DESCRIPTION
`enip.connect` and `Controller.connect` can accept FQDN provided it resolves to an IP Address

### Description, Motivation, and Context
Allows access to PLC's with FQDN

## How Has This Been Tested?
- `npm run test:local` passes
- functional test passes

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This is a work in progress, and I want some feedback (If yes, please mark it in the title -> e.g. `[WIP] Some awesome PR title`)

## Related Issue

Fix #11 
