### PR TITLE
Adds tag keepAlive parameter and KeepAlive event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ethernet-ip",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "description": "A simple node interface for Ethernet/IP.",
     "main": "./src/index.js",
     "scripts": {

--- a/src/tag/index.js
+++ b/src/tag/index.js
@@ -15,6 +15,8 @@ class Tag extends EventEmitter {
         if (!Tag.isValidTagname(tagname)) throw new Error("Tagname Must be of Type <string>");
         if (!isValidTypeCode(datatype) && datatype !== null)
             throw new Error("Datatype must be a Valid Type Code <number>");
+        if (typeof keepAlive !== "number") throw new Error(`Tag expected keepAlive of type <number> instead got type <${typeof keepAlive}>`);
+        if (keepAlive < 0) throw new Error(`Tag expected keepAlive to be greater than 0, got ${keepAlive}`)
 
         // Increment Instances
         instances += 1;

--- a/src/tag/index.js
+++ b/src/tag/index.js
@@ -16,7 +16,7 @@ class Tag extends EventEmitter {
         if (!isValidTypeCode(datatype) && datatype !== null)
             throw new Error("Datatype must be a Valid Type Code <number>");
         if (typeof keepAlive !== "number") throw new Error(`Tag expected keepAlive of type <number> instead got type <${typeof keepAlive}>`);
-        if (keepAlive < 0) throw new Error(`Tag expected keepAlive to be greater than 0, got ${keepAlive}`)
+        if (keepAlive < 0) throw new Error(`Tag expected keepAlive to be greater than 0, got ${keepAlive}`);
 
         // Increment Instances
         instances += 1;

--- a/src/tag/tag.spec.js
+++ b/src/tag/tag.spec.js
@@ -83,13 +83,13 @@ describe("Tag Class", () => {
         it("should throw an error on non-number types", () => {
             expect(() => {
                 new Tag("testkeepalive", undefined, undefined, "apple");
-            }).toThrowError();
+            }).toThrowError("Tag expected keepAlive of type <number> instead got type <string>");
         });
 
         it("should throw an error if keepAlive is less than 0", () => {
             expect(() => {
                 new Tag("testkeepalive", undefined, undefined, -20);
-            }).toThrowError();
+            }).toThrowError("Tag expected keepAlive to be greater than 0, got -20");
         });
     });
 });

--- a/src/tag/tag.spec.js
+++ b/src/tag/tag.spec.js
@@ -71,4 +71,25 @@ describe("Tag Class", () => {
             expect(tag5.generateWriteMessageRequest(-10)).toMatchSnapshot();
         });
     });
+
+
+
+    describe("keepAlive parameter", () => {
+        it("should allow a number input", () => {
+            const testTag = new Tag("testkeepalive", undefined, undefined, 10);
+            expect(testTag).toBeInstanceOf(Tag);
+        });
+
+        it("should throw an error on non-number types", () => {
+            expect(() => {
+                new Tag("testkeepalive", undefined, undefined, "apple");
+            }).toThrowError();
+        });
+
+        it("should throw an error if keepAlive is less than 0", () => {
+            expect(() => {
+                new Tag("testkeepalive", undefined, undefined, -20);
+            }).toThrowError();
+        });
+    });
 });


### PR DESCRIPTION
- If keepAlive > 0, the tag will emit a KeepAlive event every keepAlive seconds.
- The value defaults to 0 (keepAlive disabled).

### Description, Motivation, and Context

In order to keep values current, implement a KeepAlive event to periodically (but infrequently) update the stored value of the tag based on a keepAlive property of the tag.

## How Has This Been Tested?
All tests pass, functional test completed

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This is a work in progress, and I want some feedback (If yes, please mark it in the title -> e.g. `[WIP] Some awesome PR title`)

## Related Issue
#15 
