### PR TITLE
Allow 1-character Tag Names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ethernet-ip",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "description": "A simple node interface for Ethernet/IP.",
     "main": "./src/index.js",
     "scripts": {

--- a/src/tag/index.js
+++ b/src/tag/index.js
@@ -201,7 +201,7 @@ class Tag extends EventEmitter {
                     this.emit("KeepAlive", this);
                 }
             }
-            
+
         }
     }
 
@@ -421,7 +421,7 @@ class Tag extends EventEmitter {
         const tag = tagname.split(".");
 
         const test = tag[tag.length - 1];
-        const regex = /^[a-zA-Z_][a-zA-Z0-9_]*([a-zA-Z0-9_]|\[\d+\])$/i; // regex string to check for valid tagnames
+        const regex = /^[a-zA-Z_][a-zA-Z0-9_]*([a-zA-Z0-9_]*|\[\d+\])$/i; // regex string to check for valid tagnames
         return typeof tagname === "string" && regex.test(test) && test.length <= 40;
     }
     // endregion

--- a/src/tag/tag.spec.js
+++ b/src/tag/tag.spec.js
@@ -26,6 +26,8 @@ describe("Tag Class", () => {
             expect(fn(undefined)).toBeFalsy();
             expect(fn(`hello${311}`)).toBeTruthy();
             expect(fn("hello.how3")).toBeTruthy();
+            expect(fn("randy.julian.bubbles")).toBeTruthy();
+            expect(fn("a.b.c")).toBeTruthy();
             expect(fn({ prop: "value" })).toBeFalsy();
             expect(fn("fffffffffffffffffffffffffffffffffffffffff")).toBeFalsy();
             expect(fn("ffffffffffffffffffffffffffffffffffffffff")).toBeTruthy();

--- a/src/tag/tag.spec.js
+++ b/src/tag/tag.spec.js
@@ -28,6 +28,7 @@ describe("Tag Class", () => {
             expect(fn("hello.how3")).toBeTruthy();
             expect(fn("randy.julian.bubbles")).toBeTruthy();
             expect(fn("a.b.c")).toBeTruthy();
+            expect(fn("1.1.1")).toBeFalsy();
             expect(fn({ prop: "value" })).toBeFalsy();
             expect(fn("fffffffffffffffffffffffffffffffffffffffff")).toBeFalsy();
             expect(fn("ffffffffffffffffffffffffffffffffffffffff")).toBeTruthy();


### PR DESCRIPTION
Fix for cmseaton42/node-ethernet-ip#17

Allows 1-character tag names. These tag names are valid tag names as long as the 1 character is not a number.

### Description, Motivation, and Context
fixes regex in src/tag/index.js and adds tests

## How Has This Been Tested?
tests added to src/tag/tag.spec.js

## Screenshots (if appropriate):
n/a

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This is a work in progress, and I want some feedback (If yes, please mark it in the title -> e.g. `[WIP] Some awesome PR title`)

## Related Issue

#17 
