### PR TITLE
Atomic BOOL seem to return 0x01 rather than 0xff.

### DIFF
--- a/src/tag/index.js
+++ b/src/tag/index.js
@@ -423,7 +423,7 @@ class Tag extends EventEmitter {
                 this.controller_value = data.readFloatLE(2);
                 break;
             case BOOL:
-                this.controller_value = data.readUInt8(2) === 0xff ? true : false;
+                this.controller_value = data.readUInt8(2) !== 0;
                 break;
             default:
                 throw new Error(


### PR DESCRIPTION
### Description, Motivation, and Context

This simply changes the way BOOL are checked when parsed atomically

## How Has This Been Tested?

Yes, locally on a Logix5572 (Firmware 31.011)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] This is a work in progress, and I want some feedback (If yes, please mark it in the title -> e.g. `[WIP] Some awesome PR title`)

## Related Issue

See issue [#29](https://github.com/cmseaton42/node-ethernet-ip/issues/29)
