### PR TITLE
Support for base EtherNet/IP Commands and Discovering Devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Ignore Local Script Folder
 /scripts
+
+# Ignore local test
+/src/maintest.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "ethernet-ip",
-    "version": "1.2.1",
+    "version": "1.2.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -10,7 +10,7 @@
             "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.0.0"
+                "@babel/highlight": "7.0.0"
             }
         },
         "@babel/highlight": {
@@ -19,9 +19,9 @@
             "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.0",
-                "esutils": "^2.0.2",
-                "js-tokens": "^4.0.0"
+                "chalk": "2.4.1",
+                "esutils": "2.0.2",
+                "js-tokens": "4.0.0"
             },
             "dependencies": {
                 "js-tokens": {
@@ -50,7 +50,7 @@
             "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
             "dev": true,
             "requires": {
-                "acorn": "^5.0.0"
+                "acorn": "5.7.3"
             }
         },
         "acorn-jsx": {
@@ -59,7 +59,7 @@
             "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
             "dev": true,
             "requires": {
-                "acorn": "^3.0.4"
+                "acorn": "3.3.0"
             },
             "dependencies": {
                 "acorn": {
@@ -76,10 +76,10 @@
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "dev": true,
             "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
+                "co": "4.6.0",
+                "fast-deep-equal": "1.1.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
             }
         },
         "ajv-keywords": {
@@ -112,8 +112,8 @@
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
             "dev": true,
             "requires": {
-                "micromatch": "^3.1.4",
-                "normalize-path": "^2.1.1"
+                "micromatch": "3.1.10",
+                "normalize-path": "2.1.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -134,16 +134,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
+                        "arr-flatten": "1.1.0",
+                        "array-unique": "0.3.2",
+                        "extend-shallow": "2.0.1",
+                        "fill-range": "4.0.0",
+                        "isobject": "3.0.1",
+                        "repeat-element": "1.1.3",
+                        "snapdragon": "0.8.2",
+                        "snapdragon-node": "2.1.1",
+                        "split-string": "3.1.0",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -152,7 +152,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -172,13 +172,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "^2.3.3",
-                        "define-property": "^0.2.5",
-                        "extend-shallow": "^2.0.1",
-                        "posix-character-classes": "^0.1.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
+                        "debug": "2.6.9",
+                        "define-property": "0.2.5",
+                        "extend-shallow": "2.0.1",
+                        "posix-character-classes": "0.1.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "define-property": {
@@ -187,7 +187,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^0.1.0"
+                                "is-descriptor": "0.1.6"
                             }
                         },
                         "extend-shallow": {
@@ -196,7 +196,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -205,7 +205,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "^3.0.2"
+                                "kind-of": "3.2.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -214,7 +214,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "^1.1.5"
+                                        "is-buffer": "1.1.6"
                                     }
                                 }
                             }
@@ -225,7 +225,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "^3.0.2"
+                                "kind-of": "3.2.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -234,7 +234,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "^1.1.5"
+                                        "is-buffer": "1.1.6"
                                     }
                                 }
                             }
@@ -245,9 +245,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "^0.1.6",
-                                "is-data-descriptor": "^0.1.4",
-                                "kind-of": "^5.0.0"
+                                "is-accessor-descriptor": "0.1.6",
+                                "is-data-descriptor": "0.1.4",
+                                "kind-of": "5.1.0"
                             }
                         },
                         "kind-of": {
@@ -264,14 +264,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "^0.3.2",
-                        "define-property": "^1.0.0",
-                        "expand-brackets": "^2.1.4",
-                        "extend-shallow": "^2.0.1",
-                        "fragment-cache": "^0.2.1",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
+                        "array-unique": "0.3.2",
+                        "define-property": "1.0.0",
+                        "expand-brackets": "2.1.4",
+                        "extend-shallow": "2.0.1",
+                        "fragment-cache": "0.2.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "define-property": {
@@ -280,7 +280,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^1.0.0"
+                                "is-descriptor": "1.0.2"
                             }
                         },
                         "extend-shallow": {
@@ -289,7 +289,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -300,10 +300,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
+                        "extend-shallow": "2.0.1",
+                        "is-number": "3.0.0",
+                        "repeat-string": "1.6.1",
+                        "to-regex-range": "2.1.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -312,7 +312,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -323,7 +323,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -332,7 +332,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -341,9 +341,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-number": {
@@ -352,7 +352,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -361,7 +361,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -384,19 +384,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "braces": "^2.3.1",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "extglob": "^2.0.4",
-                        "fragment-cache": "^0.2.1",
-                        "kind-of": "^6.0.2",
-                        "nanomatch": "^1.2.9",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.2"
+                        "arr-diff": "4.0.0",
+                        "array-unique": "0.3.2",
+                        "braces": "2.3.2",
+                        "define-property": "2.0.2",
+                        "extend-shallow": "3.0.2",
+                        "extglob": "2.0.4",
+                        "fragment-cache": "0.2.1",
+                        "kind-of": "6.0.2",
+                        "nanomatch": "1.2.13",
+                        "object.pick": "1.3.0",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     }
                 },
                 "ms": {
@@ -413,7 +413,7 @@
             "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
             "dev": true,
             "requires": {
-                "default-require-extensions": "^1.0.0"
+                "default-require-extensions": "1.0.0"
             }
         },
         "argparse": {
@@ -422,7 +422,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "~1.0.2"
+                "sprintf-js": "1.0.3"
             }
         },
         "arr-diff": {
@@ -431,7 +431,7 @@
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
             "dev": true,
             "requires": {
-                "arr-flatten": "^1.0.1"
+                "arr-flatten": "1.1.0"
             }
         },
         "arr-flatten": {
@@ -458,7 +458,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "^1.0.1"
+                "array-uniq": "1.0.3"
             }
         },
         "array-uniq": {
@@ -485,7 +485,7 @@
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "dev": true,
             "requires": {
-                "safer-buffer": "~2.1.0"
+                "safer-buffer": "2.1.2"
             }
         },
         "assert-plus": {
@@ -512,7 +512,7 @@
             "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.10"
+                "lodash": "4.17.11"
             }
         },
         "async-limiter": {
@@ -551,9 +551,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
             },
             "dependencies": {
                 "chalk": {
@@ -562,11 +562,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -575,7 +575,7 @@
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 }
             }
@@ -586,25 +586,25 @@
             "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
             "dev": true,
             "requires": {
-                "babel-code-frame": "^6.26.0",
-                "babel-generator": "^6.26.0",
-                "babel-helpers": "^6.24.1",
-                "babel-messages": "^6.23.0",
-                "babel-register": "^6.26.0",
-                "babel-runtime": "^6.26.0",
-                "babel-template": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "convert-source-map": "^1.5.1",
-                "debug": "^2.6.9",
-                "json5": "^0.5.1",
-                "lodash": "^4.17.4",
-                "minimatch": "^3.0.4",
-                "path-is-absolute": "^1.0.1",
-                "private": "^0.1.8",
-                "slash": "^1.0.0",
-                "source-map": "^0.5.7"
+                "babel-code-frame": "6.26.0",
+                "babel-generator": "6.26.1",
+                "babel-helpers": "6.24.1",
+                "babel-messages": "6.23.0",
+                "babel-register": "6.26.0",
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "convert-source-map": "1.6.0",
+                "debug": "2.6.9",
+                "json5": "0.5.1",
+                "lodash": "4.17.11",
+                "minimatch": "3.0.4",
+                "path-is-absolute": "1.0.1",
+                "private": "0.1.8",
+                "slash": "1.0.0",
+                "source-map": "0.5.7"
             },
             "dependencies": {
                 "debug": {
@@ -630,14 +630,14 @@
             "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
             "dev": true,
             "requires": {
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "detect-indent": "^4.0.0",
-                "jsesc": "^1.3.0",
-                "lodash": "^4.17.4",
-                "source-map": "^0.5.7",
-                "trim-right": "^1.0.1"
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "detect-indent": "4.0.0",
+                "jsesc": "1.3.0",
+                "lodash": "4.17.11",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
             }
         },
         "babel-helpers": {
@@ -646,8 +646,8 @@
             "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
+                "babel-runtime": "6.26.0",
+                "babel-template": "6.26.0"
             }
         },
         "babel-jest": {
@@ -656,8 +656,8 @@
             "integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
             "dev": true,
             "requires": {
-                "babel-plugin-istanbul": "^4.1.6",
-                "babel-preset-jest": "^23.2.0"
+                "babel-plugin-istanbul": "4.1.6",
+                "babel-preset-jest": "23.2.0"
             }
         },
         "babel-messages": {
@@ -666,7 +666,7 @@
             "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.22.0"
+                "babel-runtime": "6.26.0"
             }
         },
         "babel-plugin-istanbul": {
@@ -675,10 +675,10 @@
             "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
             "dev": true,
             "requires": {
-                "babel-plugin-syntax-object-rest-spread": "^6.13.0",
-                "find-up": "^2.1.0",
-                "istanbul-lib-instrument": "^1.10.1",
-                "test-exclude": "^4.2.1"
+                "babel-plugin-syntax-object-rest-spread": "6.13.0",
+                "find-up": "2.1.0",
+                "istanbul-lib-instrument": "1.10.2",
+                "test-exclude": "4.2.3"
             }
         },
         "babel-plugin-jest-hoist": {
@@ -699,8 +699,8 @@
             "integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
             "dev": true,
             "requires": {
-                "babel-plugin-jest-hoist": "^23.2.0",
-                "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+                "babel-plugin-jest-hoist": "23.2.0",
+                "babel-plugin-syntax-object-rest-spread": "6.13.0"
             }
         },
         "babel-register": {
@@ -709,13 +709,13 @@
             "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
             "dev": true,
             "requires": {
-                "babel-core": "^6.26.0",
-                "babel-runtime": "^6.26.0",
-                "core-js": "^2.5.0",
-                "home-or-tmp": "^2.0.0",
-                "lodash": "^4.17.4",
-                "mkdirp": "^0.5.1",
-                "source-map-support": "^0.4.15"
+                "babel-core": "6.26.3",
+                "babel-runtime": "6.26.0",
+                "core-js": "2.5.7",
+                "home-or-tmp": "2.0.0",
+                "lodash": "4.17.11",
+                "mkdirp": "0.5.1",
+                "source-map-support": "0.4.18"
             }
         },
         "babel-runtime": {
@@ -724,8 +724,8 @@
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "dev": true,
             "requires": {
-                "core-js": "^2.4.0",
-                "regenerator-runtime": "^0.11.0"
+                "core-js": "2.5.7",
+                "regenerator-runtime": "0.11.1"
             }
         },
         "babel-template": {
@@ -734,11 +734,11 @@
             "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.26.0",
-                "babel-traverse": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "lodash": "^4.17.4"
+                "babel-runtime": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "lodash": "4.17.11"
             }
         },
         "babel-traverse": {
@@ -747,15 +747,15 @@
             "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "^6.26.0",
-                "babel-messages": "^6.23.0",
-                "babel-runtime": "^6.26.0",
-                "babel-types": "^6.26.0",
-                "babylon": "^6.18.0",
-                "debug": "^2.6.8",
-                "globals": "^9.18.0",
-                "invariant": "^2.2.2",
-                "lodash": "^4.17.4"
+                "babel-code-frame": "6.26.0",
+                "babel-messages": "6.23.0",
+                "babel-runtime": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "debug": "2.6.9",
+                "globals": "9.18.0",
+                "invariant": "2.2.4",
+                "lodash": "4.17.11"
             },
             "dependencies": {
                 "debug": {
@@ -787,10 +787,10 @@
             "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
             "dev": true,
             "requires": {
-                "babel-runtime": "^6.26.0",
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.4",
-                "to-fast-properties": "^1.0.3"
+                "babel-runtime": "6.26.0",
+                "esutils": "2.0.2",
+                "lodash": "4.17.11",
+                "to-fast-properties": "1.0.3"
             }
         },
         "babylon": {
@@ -811,13 +811,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "^1.0.1",
-                "class-utils": "^0.3.5",
-                "component-emitter": "^1.2.1",
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.1",
-                "mixin-deep": "^1.2.0",
-                "pascalcase": "^0.1.1"
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.6",
+                "component-emitter": "1.2.1",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.1",
+                "pascalcase": "0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -826,7 +826,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -835,7 +835,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -844,7 +844,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -853,9 +853,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 },
                 "isobject": {
@@ -879,7 +879,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "tweetnacl": "^0.14.3"
+                "tweetnacl": "0.14.5"
             }
         },
         "brace-expansion": {
@@ -888,7 +888,7 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -898,9 +898,9 @@
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
             "requires": {
-                "expand-range": "^1.8.1",
-                "preserve": "^0.2.0",
-                "repeat-element": "^1.1.2"
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.3"
             }
         },
         "browser-process-hrtime": {
@@ -924,7 +924,7 @@
             "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
             "dev": true,
             "requires": {
-                "node-int64": "^0.4.0"
+                "node-int64": "0.4.0"
             }
         },
         "buffer-from": {
@@ -945,15 +945,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "^1.0.0",
-                "component-emitter": "^1.2.1",
-                "get-value": "^2.0.6",
-                "has-value": "^1.0.0",
-                "isobject": "^3.0.1",
-                "set-value": "^2.0.0",
-                "to-object-path": "^0.3.0",
-                "union-value": "^1.0.0",
-                "unset-value": "^1.0.0"
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.2.1",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.0",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.0",
+                "unset-value": "1.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -970,7 +970,7 @@
             "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
             "dev": true,
             "requires": {
-                "callsites": "^0.2.0"
+                "callsites": "0.2.0"
             }
         },
         "callsites": {
@@ -991,7 +991,7 @@
             "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
             "dev": true,
             "requires": {
-                "rsvp": "^3.3.3"
+                "rsvp": "3.6.2"
             }
         },
         "caseless": {
@@ -1006,9 +1006,9 @@
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.5.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -1017,7 +1017,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.3"
                     }
                 },
                 "supports-color": {
@@ -1026,7 +1026,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -1055,10 +1055,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "^3.1.0",
-                "define-property": "^0.2.5",
-                "isobject": "^3.0.0",
-                "static-extend": "^0.1.1"
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "static-extend": "0.1.2"
             },
             "dependencies": {
                 "define-property": {
@@ -1067,7 +1067,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "isobject": {
@@ -1084,7 +1084,7 @@
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "^2.0.0"
+                "restore-cursor": "2.0.0"
             }
         },
         "cli-width": {
@@ -1099,9 +1099,9 @@
             "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
             "dev": true,
             "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "wrap-ansi": "2.1.0"
             }
         },
         "co": {
@@ -1122,8 +1122,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "^1.0.0",
-                "object-visit": "^1.0.0"
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
             }
         },
         "color-convert": {
@@ -1153,7 +1153,7 @@
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "dev": true,
             "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
             }
         },
         "commander": {
@@ -1181,10 +1181,10 @@
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "dev": true,
             "requires": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
+                "buffer-from": "1.1.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.6",
+                "typedarray": "0.0.6"
             }
         },
         "convert-source-map": {
@@ -1193,7 +1193,7 @@
             "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "~5.1.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "copy-descriptor": {
@@ -1220,12 +1220,12 @@
             "integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
             "dev": true,
             "requires": {
-                "growl": "~> 1.10.0",
-                "js-yaml": "^3.11.0",
-                "lcov-parse": "^0.0.10",
-                "log-driver": "^1.2.7",
-                "minimist": "^1.2.0",
-                "request": "^2.85.0"
+                "growl": "1.10.5",
+                "js-yaml": "3.12.0",
+                "lcov-parse": "0.0.10",
+                "log-driver": "1.2.7",
+                "minimist": "1.2.0",
+                "request": "2.88.0"
             }
         },
         "cross-spawn": {
@@ -1234,9 +1234,9 @@
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "dev": true,
             "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
+                "lru-cache": "4.1.3",
+                "shebang-command": "1.2.0",
+                "which": "1.3.1"
             }
         },
         "cssom": {
@@ -1251,7 +1251,7 @@
             "integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
             "dev": true,
             "requires": {
-                "cssom": "0.3.x"
+                "cssom": "0.3.4"
             }
         },
         "dashdash": {
@@ -1260,7 +1260,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "data-urls": {
@@ -1269,9 +1269,9 @@
             "integrity": "sha512-0HdcMZzK6ubMUnsMmQmG0AcLQPvbvb47R0+7CCZQCYgcd8OUWG91CG7sM6GoXgjz+WLl4ArFzHtBMy/QqSF4eg==",
             "dev": true,
             "requires": {
-                "abab": "^2.0.0",
-                "whatwg-mimetype": "^2.1.0",
-                "whatwg-url": "^7.0.0"
+                "abab": "2.0.0",
+                "whatwg-mimetype": "2.1.0",
+                "whatwg-url": "7.0.0"
             },
             "dependencies": {
                 "whatwg-url": {
@@ -1280,9 +1280,9 @@
                     "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
                     "dev": true,
                     "requires": {
-                        "lodash.sortby": "^4.7.0",
-                        "tr46": "^1.0.1",
-                        "webidl-conversions": "^4.0.2"
+                        "lodash.sortby": "4.7.0",
+                        "tr46": "1.0.1",
+                        "webidl-conversions": "4.0.2"
                     }
                 }
             }
@@ -1298,7 +1298,7 @@
             "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
             "dev": true,
             "requires": {
-                "ms": "^2.1.1"
+                "ms": "2.1.1"
             }
         },
         "decamelize": {
@@ -1325,7 +1325,7 @@
             "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
             "dev": true,
             "requires": {
-                "strip-bom": "^2.0.0"
+                "strip-bom": "2.0.0"
             }
         },
         "define-properties": {
@@ -1334,7 +1334,7 @@
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
             "dev": true,
             "requires": {
-                "object-keys": "^1.0.12"
+                "object-keys": "1.0.12"
             }
         },
         "define-property": {
@@ -1343,8 +1343,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "^1.0.2",
-                "isobject": "^3.0.1"
+                "is-descriptor": "1.0.2",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -1353,7 +1353,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -1362,7 +1362,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -1371,9 +1371,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 },
                 "isobject": {
@@ -1396,13 +1396,13 @@
             "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
             "dev": true,
             "requires": {
-                "globby": "^5.0.0",
-                "is-path-cwd": "^1.0.0",
-                "is-path-in-cwd": "^1.0.0",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0",
-                "rimraf": "^2.2.8"
+                "globby": "5.0.0",
+                "is-path-cwd": "1.0.0",
+                "is-path-in-cwd": "1.0.1",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "rimraf": "2.6.2"
             }
         },
         "delayed-stream": {
@@ -1417,7 +1417,7 @@
             "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
             "dev": true,
             "requires": {
-                "repeating": "^2.0.0"
+                "repeating": "2.0.1"
             }
         },
         "detect-newline": {
@@ -1438,7 +1438,7 @@
             "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
             "dev": true,
             "requires": {
-                "esutils": "^2.0.2"
+                "esutils": "2.0.2"
             }
         },
         "domexception": {
@@ -1447,7 +1447,7 @@
             "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
             "dev": true,
             "requires": {
-                "webidl-conversions": "^4.0.2"
+                "webidl-conversions": "4.0.2"
             }
         },
         "ecc-jsbn": {
@@ -1457,8 +1457,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2"
             }
         },
         "error-ex": {
@@ -1467,7 +1467,7 @@
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
             "dev": true,
             "requires": {
-                "is-arrayish": "^0.2.1"
+                "is-arrayish": "0.2.1"
             }
         },
         "es-abstract": {
@@ -1476,11 +1476,11 @@
             "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
             "dev": true,
             "requires": {
-                "es-to-primitive": "^1.1.1",
-                "function-bind": "^1.1.1",
-                "has": "^1.0.1",
-                "is-callable": "^1.1.3",
-                "is-regex": "^1.0.4"
+                "es-to-primitive": "1.1.1",
+                "function-bind": "1.1.1",
+                "has": "1.0.3",
+                "is-callable": "1.1.4",
+                "is-regex": "1.0.4"
             }
         },
         "es-to-primitive": {
@@ -1489,9 +1489,9 @@
             "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
             "dev": true,
             "requires": {
-                "is-callable": "^1.1.1",
-                "is-date-object": "^1.0.1",
-                "is-symbol": "^1.0.1"
+                "is-callable": "1.1.4",
+                "is-date-object": "1.0.1",
+                "is-symbol": "1.0.1"
             }
         },
         "escape-string-regexp": {
@@ -1506,11 +1506,11 @@
             "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
             "dev": true,
             "requires": {
-                "esprima": "^3.1.3",
-                "estraverse": "^4.2.0",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.6.1"
+                "esprima": "3.1.3",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "esprima": {
@@ -1534,44 +1534,44 @@
             "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
             "dev": true,
             "requires": {
-                "ajv": "^5.3.0",
-                "babel-code-frame": "^6.22.0",
-                "chalk": "^2.1.0",
-                "concat-stream": "^1.6.0",
-                "cross-spawn": "^5.1.0",
-                "debug": "^3.1.0",
-                "doctrine": "^2.1.0",
-                "eslint-scope": "^3.7.1",
-                "eslint-visitor-keys": "^1.0.0",
-                "espree": "^3.5.4",
-                "esquery": "^1.0.0",
-                "esutils": "^2.0.2",
-                "file-entry-cache": "^2.0.0",
-                "functional-red-black-tree": "^1.0.1",
-                "glob": "^7.1.2",
-                "globals": "^11.0.1",
-                "ignore": "^3.3.3",
-                "imurmurhash": "^0.1.4",
-                "inquirer": "^3.0.6",
-                "is-resolvable": "^1.0.0",
-                "js-yaml": "^3.9.1",
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.3.0",
-                "lodash": "^4.17.4",
-                "minimatch": "^3.0.2",
-                "mkdirp": "^0.5.1",
-                "natural-compare": "^1.4.0",
-                "optionator": "^0.8.2",
-                "path-is-inside": "^1.0.2",
-                "pluralize": "^7.0.0",
-                "progress": "^2.0.0",
-                "regexpp": "^1.0.1",
-                "require-uncached": "^1.0.3",
-                "semver": "^5.3.0",
-                "strip-ansi": "^4.0.0",
-                "strip-json-comments": "~2.0.1",
+                "ajv": "5.5.2",
+                "babel-code-frame": "6.26.0",
+                "chalk": "2.4.1",
+                "concat-stream": "1.6.2",
+                "cross-spawn": "5.1.0",
+                "debug": "3.2.5",
+                "doctrine": "2.1.0",
+                "eslint-scope": "3.7.3",
+                "eslint-visitor-keys": "1.0.0",
+                "espree": "3.5.4",
+                "esquery": "1.0.1",
+                "esutils": "2.0.2",
+                "file-entry-cache": "2.0.0",
+                "functional-red-black-tree": "1.0.1",
+                "glob": "7.1.3",
+                "globals": "11.7.0",
+                "ignore": "3.3.10",
+                "imurmurhash": "0.1.4",
+                "inquirer": "3.3.0",
+                "is-resolvable": "1.1.0",
+                "js-yaml": "3.12.0",
+                "json-stable-stringify-without-jsonify": "1.0.1",
+                "levn": "0.3.0",
+                "lodash": "4.17.11",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "optionator": "0.8.2",
+                "path-is-inside": "1.0.2",
+                "pluralize": "7.0.0",
+                "progress": "2.0.0",
+                "regexpp": "1.1.0",
+                "require-uncached": "1.0.3",
+                "semver": "5.5.1",
+                "strip-ansi": "4.0.0",
+                "strip-json-comments": "2.0.1",
                 "table": "4.0.2",
-                "text-table": "~0.2.0"
+                "text-table": "0.2.0"
             }
         },
         "eslint-plugin-jest": {
@@ -1586,8 +1586,8 @@
             "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
             "dev": true,
             "requires": {
-                "esrecurse": "^4.1.0",
-                "estraverse": "^4.1.1"
+                "esrecurse": "4.2.1",
+                "estraverse": "4.2.0"
             }
         },
         "eslint-visitor-keys": {
@@ -1602,8 +1602,8 @@
             "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
             "dev": true,
             "requires": {
-                "acorn": "^5.5.0",
-                "acorn-jsx": "^3.0.0"
+                "acorn": "5.7.3",
+                "acorn-jsx": "3.0.1"
             }
         },
         "esprima": {
@@ -1618,7 +1618,7 @@
             "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
             "dev": true,
             "requires": {
-                "estraverse": "^4.0.0"
+                "estraverse": "4.2.0"
             }
         },
         "esrecurse": {
@@ -1627,7 +1627,7 @@
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
-                "estraverse": "^4.1.0"
+                "estraverse": "4.2.0"
             }
         },
         "estraverse": {
@@ -1648,7 +1648,7 @@
             "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
             "dev": true,
             "requires": {
-                "merge": "^1.2.0"
+                "merge": "1.2.0"
             }
         },
         "execa": {
@@ -1657,13 +1657,13 @@
             "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
             "dev": true,
             "requires": {
-                "cross-spawn": "^5.0.1",
-                "get-stream": "^3.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
+                "cross-spawn": "5.1.0",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
             }
         },
         "exit": {
@@ -1678,7 +1678,7 @@
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
             "requires": {
-                "is-posix-bracket": "^0.1.0"
+                "is-posix-bracket": "0.1.1"
             }
         },
         "expand-range": {
@@ -1687,7 +1687,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "^2.1.0"
+                "fill-range": "2.2.4"
             }
         },
         "expect": {
@@ -1696,12 +1696,12 @@
             "integrity": "sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^3.2.0",
-                "jest-diff": "^23.6.0",
-                "jest-get-type": "^22.1.0",
-                "jest-matcher-utils": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-regex-util": "^23.3.0"
+                "ansi-styles": "3.2.1",
+                "jest-diff": "23.6.0",
+                "jest-get-type": "22.4.3",
+                "jest-matcher-utils": "23.6.0",
+                "jest-message-util": "23.4.0",
+                "jest-regex-util": "23.3.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -1710,7 +1710,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.3"
                     }
                 }
             }
@@ -1727,8 +1727,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "^1.0.0",
-                "is-extendable": "^1.0.1"
+                "assign-symbols": "1.0.0",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -1737,7 +1737,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 }
             }
@@ -1748,9 +1748,9 @@
             "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
             "dev": true,
             "requires": {
-                "chardet": "^0.4.0",
-                "iconv-lite": "^0.4.17",
-                "tmp": "^0.0.33"
+                "chardet": "0.4.2",
+                "iconv-lite": "0.4.24",
+                "tmp": "0.0.33"
             }
         },
         "extglob": {
@@ -1759,7 +1759,7 @@
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
             "requires": {
-                "is-extglob": "^1.0.0"
+                "is-extglob": "1.0.0"
             }
         },
         "extsprintf": {
@@ -1792,7 +1792,7 @@
             "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
             "dev": true,
             "requires": {
-                "bser": "^2.0.0"
+                "bser": "2.0.0"
             }
         },
         "figures": {
@@ -1801,7 +1801,7 @@
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "^1.0.5"
+                "escape-string-regexp": "1.0.5"
             }
         },
         "file-entry-cache": {
@@ -1810,8 +1810,8 @@
             "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
             "dev": true,
             "requires": {
-                "flat-cache": "^1.2.1",
-                "object-assign": "^4.0.1"
+                "flat-cache": "1.3.0",
+                "object-assign": "4.1.1"
             }
         },
         "filename-regex": {
@@ -1826,8 +1826,8 @@
             "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
             "dev": true,
             "requires": {
-                "glob": "^7.0.3",
-                "minimatch": "^3.0.3"
+                "glob": "7.1.3",
+                "minimatch": "3.0.4"
             }
         },
         "fill-range": {
@@ -1836,11 +1836,11 @@
             "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
             "dev": true,
             "requires": {
-                "is-number": "^2.1.0",
-                "isobject": "^2.0.0",
-                "randomatic": "^3.0.0",
-                "repeat-element": "^1.1.2",
-                "repeat-string": "^1.5.2"
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "3.1.0",
+                "repeat-element": "1.1.3",
+                "repeat-string": "1.6.1"
             }
         },
         "find-up": {
@@ -1849,7 +1849,7 @@
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "dev": true,
             "requires": {
-                "locate-path": "^2.0.0"
+                "locate-path": "2.0.0"
             }
         },
         "flat-cache": {
@@ -1858,10 +1858,10 @@
             "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
             "dev": true,
             "requires": {
-                "circular-json": "^0.3.1",
-                "del": "^2.0.2",
-                "graceful-fs": "^4.1.2",
-                "write": "^0.2.1"
+                "circular-json": "0.3.3",
+                "del": "2.2.2",
+                "graceful-fs": "4.1.11",
+                "write": "0.2.1"
             }
         },
         "for-in": {
@@ -1876,7 +1876,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "^1.0.1"
+                "for-in": "1.0.2"
             }
         },
         "forever-agent": {
@@ -1891,9 +1891,9 @@
             "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "dev": true,
             "requires": {
-                "asynckit": "^0.4.0",
+                "asynckit": "0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "^2.1.12"
+                "mime-types": "2.1.20"
             }
         },
         "fragment-cache": {
@@ -1902,7 +1902,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "^0.2.2"
+                "map-cache": "0.2.2"
             }
         },
         "fs.realpath": {
@@ -1918,8 +1918,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "^2.9.2",
-                "node-pre-gyp": "^0.10.0"
+                "nan": "2.11.0",
+                "node-pre-gyp": "0.10.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -1945,8 +1945,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "^1.0.0",
-                        "readable-stream": "^2.0.6"
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.3.6"
                     }
                 },
                 "balanced-match": {
@@ -1959,7 +1959,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -2023,7 +2023,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "^2.2.1"
+                        "minipass": "2.2.4"
                     }
                 },
                 "fs.realpath": {
@@ -2038,14 +2038,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "^1.0.3",
-                        "console-control-strings": "^1.0.0",
-                        "has-unicode": "^2.0.0",
-                        "object-assign": "^4.1.0",
-                        "signal-exit": "^3.0.0",
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wide-align": "^1.1.0"
+                        "aproba": "1.2.0",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
                     }
                 },
                 "glob": {
@@ -2054,12 +2054,12 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "has-unicode": {
@@ -2074,7 +2074,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "^2.1.0"
+                        "safer-buffer": "2.1.2"
                     }
                 },
                 "ignore-walk": {
@@ -2083,7 +2083,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minimatch": "^3.0.4"
+                        "minimatch": "3.0.4"
                     }
                 },
                 "inflight": {
@@ -2092,8 +2092,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
                     }
                 },
                 "inherits": {
@@ -2112,7 +2112,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                     }
                 },
                 "isarray": {
@@ -2126,7 +2126,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.11"
                     }
                 },
                 "minimist": {
@@ -2139,8 +2139,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "^5.1.1",
-                        "yallist": "^3.0.0"
+                        "safe-buffer": "5.1.1",
+                        "yallist": "3.0.2"
                     }
                 },
                 "minizlib": {
@@ -2149,7 +2149,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "^2.2.1"
+                        "minipass": "2.2.4"
                     }
                 },
                 "mkdirp": {
@@ -2172,9 +2172,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "^2.1.2",
-                        "iconv-lite": "^0.4.4",
-                        "sax": "^1.2.4"
+                        "debug": "2.6.9",
+                        "iconv-lite": "0.4.21",
+                        "sax": "1.2.4"
                     }
                 },
                 "node-pre-gyp": {
@@ -2183,16 +2183,16 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "^1.0.2",
-                        "mkdirp": "^0.5.1",
-                        "needle": "^2.2.0",
-                        "nopt": "^4.0.1",
-                        "npm-packlist": "^1.1.6",
-                        "npmlog": "^4.0.2",
-                        "rc": "^1.1.7",
-                        "rimraf": "^2.6.1",
-                        "semver": "^5.3.0",
-                        "tar": "^4"
+                        "detect-libc": "1.0.3",
+                        "mkdirp": "0.5.1",
+                        "needle": "2.2.0",
+                        "nopt": "4.0.1",
+                        "npm-packlist": "1.1.10",
+                        "npmlog": "4.1.2",
+                        "rc": "1.2.7",
+                        "rimraf": "2.6.2",
+                        "semver": "5.5.0",
+                        "tar": "4.4.1"
                     }
                 },
                 "nopt": {
@@ -2201,8 +2201,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1",
-                        "osenv": "^0.1.4"
+                        "abbrev": "1.1.1",
+                        "osenv": "0.1.5"
                     }
                 },
                 "npm-bundled": {
@@ -2217,8 +2217,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ignore-walk": "^3.0.1",
-                        "npm-bundled": "^1.0.1"
+                        "ignore-walk": "3.0.1",
+                        "npm-bundled": "1.0.3"
                     }
                 },
                 "npmlog": {
@@ -2227,10 +2227,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "~1.1.2",
-                        "console-control-strings": "~1.1.0",
-                        "gauge": "~2.7.3",
-                        "set-blocking": "~2.0.0"
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -2249,7 +2249,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1"
+                        "wrappy": "1.0.2"
                     }
                 },
                 "os-homedir": {
@@ -2270,8 +2270,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "^1.0.0",
-                        "os-tmpdir": "^1.0.0"
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
                     }
                 },
                 "path-is-absolute": {
@@ -2292,10 +2292,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "^0.5.1",
-                        "ini": "~1.3.0",
-                        "minimist": "^1.2.0",
-                        "strip-json-comments": "~2.0.1"
+                        "deep-extend": "0.5.1",
+                        "ini": "1.3.5",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -2312,13 +2312,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "rimraf": {
@@ -2327,7 +2327,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "7.1.2"
                     }
                 },
                 "safe-buffer": {
@@ -2370,9 +2370,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                     }
                 },
                 "string_decoder": {
@@ -2381,7 +2381,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                     }
                 },
                 "strip-ansi": {
@@ -2389,7 +2389,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 },
                 "strip-json-comments": {
@@ -2404,13 +2404,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "^1.0.1",
-                        "fs-minipass": "^1.2.5",
-                        "minipass": "^2.2.4",
-                        "minizlib": "^1.1.0",
-                        "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.1",
-                        "yallist": "^3.0.2"
+                        "chownr": "1.0.1",
+                        "fs-minipass": "1.2.5",
+                        "minipass": "2.2.4",
+                        "minizlib": "1.1.0",
+                        "mkdirp": "0.5.1",
+                        "safe-buffer": "5.1.1",
+                        "yallist": "3.0.2"
                     }
                 },
                 "util-deprecate": {
@@ -2425,7 +2425,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "^1.0.2"
+                        "string-width": "1.0.2"
                     }
                 },
                 "wrappy": {
@@ -2476,7 +2476,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "glob": {
@@ -2485,12 +2485,12 @@
             "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
             }
         },
         "glob-base": {
@@ -2499,8 +2499,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "^2.0.0",
-                "is-glob": "^2.0.0"
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
             }
         },
         "glob-parent": {
@@ -2509,7 +2509,7 @@
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
             "dev": true,
             "requires": {
-                "is-glob": "^2.0.0"
+                "is-glob": "2.0.1"
             }
         },
         "globals": {
@@ -2524,12 +2524,12 @@
             "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
             "dev": true,
             "requires": {
-                "array-union": "^1.0.1",
-                "arrify": "^1.0.0",
-                "glob": "^7.0.3",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "glob": "7.1.3",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
             }
         },
         "graceful-fs": {
@@ -2556,10 +2556,10 @@
             "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
             "dev": true,
             "requires": {
-                "async": "^2.5.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4"
+                "async": "2.6.1",
+                "optimist": "0.6.1",
+                "source-map": "0.6.1",
+                "uglify-js": "3.4.9"
             },
             "dependencies": {
                 "source-map": {
@@ -2582,8 +2582,8 @@
             "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
             "dev": true,
             "requires": {
-                "ajv": "^5.3.0",
-                "har-schema": "^2.0.0"
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
             }
         },
         "has": {
@@ -2592,7 +2592,7 @@
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "dev": true,
             "requires": {
-                "function-bind": "^1.1.1"
+                "function-bind": "1.1.1"
             }
         },
         "has-ansi": {
@@ -2601,7 +2601,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "has-flag": {
@@ -2616,9 +2616,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "^2.0.6",
-                "has-values": "^1.0.0",
-                "isobject": "^3.0.0"
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -2635,8 +2635,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "^3.0.0",
-                "kind-of": "^4.0.0"
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -2645,7 +2645,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -2654,7 +2654,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -2665,7 +2665,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -2676,8 +2676,8 @@
             "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
             "dev": true,
             "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.1"
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
             }
         },
         "hosted-git-info": {
@@ -2692,7 +2692,7 @@
             "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
             "dev": true,
             "requires": {
-                "whatwg-encoding": "^1.0.1"
+                "whatwg-encoding": "1.0.4"
             }
         },
         "http-signature": {
@@ -2701,9 +2701,9 @@
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.14.2"
             }
         },
         "iconv-lite": {
@@ -2712,7 +2712,7 @@
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
             "dev": true,
             "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "safer-buffer": "2.1.2"
             }
         },
         "ignore": {
@@ -2727,8 +2727,8 @@
             "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
             "dev": true,
             "requires": {
-                "pkg-dir": "^2.0.0",
-                "resolve-cwd": "^2.0.0"
+                "pkg-dir": "2.0.0",
+                "resolve-cwd": "2.0.0"
             }
         },
         "imurmurhash": {
@@ -2743,8 +2743,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -2759,20 +2759,20 @@
             "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.0",
-                "cli-cursor": "^2.1.0",
-                "cli-width": "^2.0.0",
-                "external-editor": "^2.0.4",
-                "figures": "^2.0.0",
-                "lodash": "^4.3.0",
+                "ansi-escapes": "3.1.0",
+                "chalk": "2.4.1",
+                "cli-cursor": "2.1.0",
+                "cli-width": "2.2.0",
+                "external-editor": "2.2.0",
+                "figures": "2.0.0",
+                "lodash": "4.17.11",
                 "mute-stream": "0.0.7",
-                "run-async": "^2.2.0",
-                "rx-lite": "^4.0.8",
-                "rx-lite-aggregates": "^4.0.8",
-                "string-width": "^2.1.0",
-                "strip-ansi": "^4.0.0",
-                "through": "^2.3.6"
+                "run-async": "2.3.0",
+                "rx-lite": "4.0.8",
+                "rx-lite-aggregates": "4.0.8",
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "through": "2.3.8"
             }
         },
         "invariant": {
@@ -2781,7 +2781,7 @@
             "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
             "dev": true,
             "requires": {
-                "loose-envify": "^1.0.0"
+                "loose-envify": "1.4.0"
             }
         },
         "invert-kv": {
@@ -2796,7 +2796,7 @@
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             }
         },
         "is-arrayish": {
@@ -2817,7 +2817,7 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "^1.0.0"
+                "builtin-modules": "1.1.1"
             }
         },
         "is-callable": {
@@ -2832,7 +2832,7 @@
             "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
             "dev": true,
             "requires": {
-                "ci-info": "^1.5.0"
+                "ci-info": "1.5.1"
             }
         },
         "is-data-descriptor": {
@@ -2841,7 +2841,7 @@
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             }
         },
         "is-date-object": {
@@ -2856,9 +2856,9 @@
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -2881,7 +2881,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "^2.0.0"
+                "is-primitive": "2.0.0"
             }
         },
         "is-extendable": {
@@ -2902,7 +2902,7 @@
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
             }
         },
         "is-fullwidth-code-point": {
@@ -2923,7 +2923,7 @@
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
             "dev": true,
             "requires": {
-                "is-extglob": "^1.0.0"
+                "is-extglob": "1.0.0"
             }
         },
         "is-number": {
@@ -2932,7 +2932,7 @@
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             }
         },
         "is-path-cwd": {
@@ -2947,7 +2947,7 @@
             "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
             "dev": true,
             "requires": {
-                "is-path-inside": "^1.0.0"
+                "is-path-inside": "1.0.1"
             }
         },
         "is-path-inside": {
@@ -2956,7 +2956,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "^1.0.1"
+                "path-is-inside": "1.0.2"
             }
         },
         "is-plain-object": {
@@ -2965,7 +2965,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -3000,7 +3000,7 @@
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
             "dev": true,
             "requires": {
-                "has": "^1.0.1"
+                "has": "1.0.3"
             }
         },
         "is-resolvable": {
@@ -3072,17 +3072,17 @@
             "integrity": "sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==",
             "dev": true,
             "requires": {
-                "async": "^2.1.4",
-                "fileset": "^2.0.2",
-                "istanbul-lib-coverage": "^1.2.1",
-                "istanbul-lib-hook": "^1.2.2",
-                "istanbul-lib-instrument": "^1.10.2",
-                "istanbul-lib-report": "^1.1.5",
-                "istanbul-lib-source-maps": "^1.2.6",
-                "istanbul-reports": "^1.5.1",
-                "js-yaml": "^3.7.0",
-                "mkdirp": "^0.5.1",
-                "once": "^1.4.0"
+                "async": "2.6.1",
+                "fileset": "2.0.3",
+                "istanbul-lib-coverage": "1.2.1",
+                "istanbul-lib-hook": "1.2.2",
+                "istanbul-lib-instrument": "1.10.2",
+                "istanbul-lib-report": "1.1.5",
+                "istanbul-lib-source-maps": "1.2.6",
+                "istanbul-reports": "1.5.1",
+                "js-yaml": "3.12.0",
+                "mkdirp": "0.5.1",
+                "once": "1.4.0"
             }
         },
         "istanbul-lib-coverage": {
@@ -3097,7 +3097,7 @@
             "integrity": "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
             "dev": true,
             "requires": {
-                "append-transform": "^0.4.0"
+                "append-transform": "0.4.0"
             }
         },
         "istanbul-lib-instrument": {
@@ -3106,13 +3106,13 @@
             "integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
             "dev": true,
             "requires": {
-                "babel-generator": "^6.18.0",
-                "babel-template": "^6.16.0",
-                "babel-traverse": "^6.18.0",
-                "babel-types": "^6.18.0",
-                "babylon": "^6.18.0",
-                "istanbul-lib-coverage": "^1.2.1",
-                "semver": "^5.3.0"
+                "babel-generator": "6.26.1",
+                "babel-template": "6.26.0",
+                "babel-traverse": "6.26.0",
+                "babel-types": "6.26.0",
+                "babylon": "6.18.0",
+                "istanbul-lib-coverage": "1.2.1",
+                "semver": "5.5.1"
             }
         },
         "istanbul-lib-report": {
@@ -3121,10 +3121,10 @@
             "integrity": "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
             "dev": true,
             "requires": {
-                "istanbul-lib-coverage": "^1.2.1",
-                "mkdirp": "^0.5.1",
-                "path-parse": "^1.0.5",
-                "supports-color": "^3.1.2"
+                "istanbul-lib-coverage": "1.2.1",
+                "mkdirp": "0.5.1",
+                "path-parse": "1.0.6",
+                "supports-color": "3.2.3"
             },
             "dependencies": {
                 "has-flag": {
@@ -3139,7 +3139,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^1.0.0"
+                        "has-flag": "1.0.0"
                     }
                 }
             }
@@ -3150,11 +3150,11 @@
             "integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
             "dev": true,
             "requires": {
-                "debug": "^3.1.0",
-                "istanbul-lib-coverage": "^1.2.1",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.6.1",
-                "source-map": "^0.5.3"
+                "debug": "3.2.5",
+                "istanbul-lib-coverage": "1.2.1",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2",
+                "source-map": "0.5.7"
             }
         },
         "istanbul-reports": {
@@ -3163,7 +3163,7 @@
             "integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
             "dev": true,
             "requires": {
-                "handlebars": "^4.0.3"
+                "handlebars": "4.0.12"
             }
         },
         "jest": {
@@ -3172,8 +3172,8 @@
             "integrity": "sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==",
             "dev": true,
             "requires": {
-                "import-local": "^1.0.0",
-                "jest-cli": "^23.6.0"
+                "import-local": "1.0.0",
+                "jest-cli": "23.6.0"
             },
             "dependencies": {
                 "jest-cli": {
@@ -3182,42 +3182,42 @@
                     "integrity": "sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-escapes": "^3.0.0",
-                        "chalk": "^2.0.1",
-                        "exit": "^0.1.2",
-                        "glob": "^7.1.2",
-                        "graceful-fs": "^4.1.11",
-                        "import-local": "^1.0.0",
-                        "is-ci": "^1.0.10",
-                        "istanbul-api": "^1.3.1",
-                        "istanbul-lib-coverage": "^1.2.0",
-                        "istanbul-lib-instrument": "^1.10.1",
-                        "istanbul-lib-source-maps": "^1.2.4",
-                        "jest-changed-files": "^23.4.2",
-                        "jest-config": "^23.6.0",
-                        "jest-environment-jsdom": "^23.4.0",
-                        "jest-get-type": "^22.1.0",
-                        "jest-haste-map": "^23.6.0",
-                        "jest-message-util": "^23.4.0",
-                        "jest-regex-util": "^23.3.0",
-                        "jest-resolve-dependencies": "^23.6.0",
-                        "jest-runner": "^23.6.0",
-                        "jest-runtime": "^23.6.0",
-                        "jest-snapshot": "^23.6.0",
-                        "jest-util": "^23.4.0",
-                        "jest-validate": "^23.6.0",
-                        "jest-watcher": "^23.4.0",
-                        "jest-worker": "^23.2.0",
-                        "micromatch": "^2.3.11",
-                        "node-notifier": "^5.2.1",
-                        "prompts": "^0.1.9",
-                        "realpath-native": "^1.0.0",
-                        "rimraf": "^2.5.4",
-                        "slash": "^1.0.0",
-                        "string-length": "^2.0.0",
-                        "strip-ansi": "^4.0.0",
-                        "which": "^1.2.12",
-                        "yargs": "^11.0.0"
+                        "ansi-escapes": "3.1.0",
+                        "chalk": "2.4.1",
+                        "exit": "0.1.2",
+                        "glob": "7.1.3",
+                        "graceful-fs": "4.1.11",
+                        "import-local": "1.0.0",
+                        "is-ci": "1.2.1",
+                        "istanbul-api": "1.3.7",
+                        "istanbul-lib-coverage": "1.2.1",
+                        "istanbul-lib-instrument": "1.10.2",
+                        "istanbul-lib-source-maps": "1.2.6",
+                        "jest-changed-files": "23.4.2",
+                        "jest-config": "23.6.0",
+                        "jest-environment-jsdom": "23.4.0",
+                        "jest-get-type": "22.4.3",
+                        "jest-haste-map": "23.6.0",
+                        "jest-message-util": "23.4.0",
+                        "jest-regex-util": "23.3.0",
+                        "jest-resolve-dependencies": "23.6.0",
+                        "jest-runner": "23.6.0",
+                        "jest-runtime": "23.6.0",
+                        "jest-snapshot": "23.6.0",
+                        "jest-util": "23.4.0",
+                        "jest-validate": "23.6.0",
+                        "jest-watcher": "23.4.0",
+                        "jest-worker": "23.2.0",
+                        "micromatch": "2.3.11",
+                        "node-notifier": "5.2.1",
+                        "prompts": "0.1.14",
+                        "realpath-native": "1.0.2",
+                        "rimraf": "2.6.2",
+                        "slash": "1.0.0",
+                        "string-length": "2.0.0",
+                        "strip-ansi": "4.0.0",
+                        "which": "1.3.1",
+                        "yargs": "11.1.0"
                     }
                 }
             }
@@ -3228,7 +3228,7 @@
             "integrity": "sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==",
             "dev": true,
             "requires": {
-                "throat": "^4.0.0"
+                "throat": "4.1.0"
             }
         },
         "jest-config": {
@@ -3237,20 +3237,20 @@
             "integrity": "sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==",
             "dev": true,
             "requires": {
-                "babel-core": "^6.0.0",
-                "babel-jest": "^23.6.0",
-                "chalk": "^2.0.1",
-                "glob": "^7.1.1",
-                "jest-environment-jsdom": "^23.4.0",
-                "jest-environment-node": "^23.4.0",
-                "jest-get-type": "^22.1.0",
-                "jest-jasmine2": "^23.6.0",
-                "jest-regex-util": "^23.3.0",
-                "jest-resolve": "^23.6.0",
-                "jest-util": "^23.4.0",
-                "jest-validate": "^23.6.0",
-                "micromatch": "^2.3.11",
-                "pretty-format": "^23.6.0"
+                "babel-core": "6.26.3",
+                "babel-jest": "23.6.0",
+                "chalk": "2.4.1",
+                "glob": "7.1.3",
+                "jest-environment-jsdom": "23.4.0",
+                "jest-environment-node": "23.4.0",
+                "jest-get-type": "22.4.3",
+                "jest-jasmine2": "23.6.0",
+                "jest-regex-util": "23.3.0",
+                "jest-resolve": "23.6.0",
+                "jest-util": "23.4.0",
+                "jest-validate": "23.6.0",
+                "micromatch": "2.3.11",
+                "pretty-format": "23.6.0"
             }
         },
         "jest-diff": {
@@ -3259,10 +3259,10 @@
             "integrity": "sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.1",
-                "diff": "^3.2.0",
-                "jest-get-type": "^22.1.0",
-                "pretty-format": "^23.6.0"
+                "chalk": "2.4.1",
+                "diff": "3.5.0",
+                "jest-get-type": "22.4.3",
+                "pretty-format": "23.6.0"
             }
         },
         "jest-docblock": {
@@ -3271,7 +3271,7 @@
             "integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
             "dev": true,
             "requires": {
-                "detect-newline": "^2.1.0"
+                "detect-newline": "2.1.0"
             }
         },
         "jest-each": {
@@ -3280,8 +3280,8 @@
             "integrity": "sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.1",
-                "pretty-format": "^23.6.0"
+                "chalk": "2.4.1",
+                "pretty-format": "23.6.0"
             }
         },
         "jest-environment-jsdom": {
@@ -3290,9 +3290,9 @@
             "integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
             "dev": true,
             "requires": {
-                "jest-mock": "^23.2.0",
-                "jest-util": "^23.4.0",
-                "jsdom": "^11.5.1"
+                "jest-mock": "23.2.0",
+                "jest-util": "23.4.0",
+                "jsdom": "11.12.0"
             }
         },
         "jest-environment-node": {
@@ -3301,8 +3301,8 @@
             "integrity": "sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=",
             "dev": true,
             "requires": {
-                "jest-mock": "^23.2.0",
-                "jest-util": "^23.4.0"
+                "jest-mock": "23.2.0",
+                "jest-util": "23.4.0"
             }
         },
         "jest-get-type": {
@@ -3317,14 +3317,14 @@
             "integrity": "sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==",
             "dev": true,
             "requires": {
-                "fb-watchman": "^2.0.0",
-                "graceful-fs": "^4.1.11",
-                "invariant": "^2.2.4",
-                "jest-docblock": "^23.2.0",
-                "jest-serializer": "^23.0.1",
-                "jest-worker": "^23.2.0",
-                "micromatch": "^2.3.11",
-                "sane": "^2.0.0"
+                "fb-watchman": "2.0.0",
+                "graceful-fs": "4.1.11",
+                "invariant": "2.2.4",
+                "jest-docblock": "23.2.0",
+                "jest-serializer": "23.0.1",
+                "jest-worker": "23.2.0",
+                "micromatch": "2.3.11",
+                "sane": "2.5.2"
             }
         },
         "jest-jasmine2": {
@@ -3333,18 +3333,18 @@
             "integrity": "sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==",
             "dev": true,
             "requires": {
-                "babel-traverse": "^6.0.0",
-                "chalk": "^2.0.1",
-                "co": "^4.6.0",
-                "expect": "^23.6.0",
-                "is-generator-fn": "^1.0.0",
-                "jest-diff": "^23.6.0",
-                "jest-each": "^23.6.0",
-                "jest-matcher-utils": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-snapshot": "^23.6.0",
-                "jest-util": "^23.4.0",
-                "pretty-format": "^23.6.0"
+                "babel-traverse": "6.26.0",
+                "chalk": "2.4.1",
+                "co": "4.6.0",
+                "expect": "23.6.0",
+                "is-generator-fn": "1.0.0",
+                "jest-diff": "23.6.0",
+                "jest-each": "23.6.0",
+                "jest-matcher-utils": "23.6.0",
+                "jest-message-util": "23.4.0",
+                "jest-snapshot": "23.6.0",
+                "jest-util": "23.4.0",
+                "pretty-format": "23.6.0"
             }
         },
         "jest-leak-detector": {
@@ -3353,7 +3353,7 @@
             "integrity": "sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==",
             "dev": true,
             "requires": {
-                "pretty-format": "^23.6.0"
+                "pretty-format": "23.6.0"
             }
         },
         "jest-matcher-utils": {
@@ -3362,9 +3362,9 @@
             "integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.1",
-                "jest-get-type": "^22.1.0",
-                "pretty-format": "^23.6.0"
+                "chalk": "2.4.1",
+                "jest-get-type": "22.4.3",
+                "pretty-format": "23.6.0"
             }
         },
         "jest-message-util": {
@@ -3373,11 +3373,11 @@
             "integrity": "sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0-beta.35",
-                "chalk": "^2.0.1",
-                "micromatch": "^2.3.11",
-                "slash": "^1.0.0",
-                "stack-utils": "^1.0.1"
+                "@babel/code-frame": "7.0.0",
+                "chalk": "2.4.1",
+                "micromatch": "2.3.11",
+                "slash": "1.0.0",
+                "stack-utils": "1.0.1"
             }
         },
         "jest-mock": {
@@ -3398,9 +3398,9 @@
             "integrity": "sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==",
             "dev": true,
             "requires": {
-                "browser-resolve": "^1.11.3",
-                "chalk": "^2.0.1",
-                "realpath-native": "^1.0.0"
+                "browser-resolve": "1.11.3",
+                "chalk": "2.4.1",
+                "realpath-native": "1.0.2"
             }
         },
         "jest-resolve-dependencies": {
@@ -3409,8 +3409,8 @@
             "integrity": "sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==",
             "dev": true,
             "requires": {
-                "jest-regex-util": "^23.3.0",
-                "jest-snapshot": "^23.6.0"
+                "jest-regex-util": "23.3.0",
+                "jest-snapshot": "23.6.0"
             }
         },
         "jest-runner": {
@@ -3419,19 +3419,19 @@
             "integrity": "sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==",
             "dev": true,
             "requires": {
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.1.11",
-                "jest-config": "^23.6.0",
-                "jest-docblock": "^23.2.0",
-                "jest-haste-map": "^23.6.0",
-                "jest-jasmine2": "^23.6.0",
-                "jest-leak-detector": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-runtime": "^23.6.0",
-                "jest-util": "^23.4.0",
-                "jest-worker": "^23.2.0",
-                "source-map-support": "^0.5.6",
-                "throat": "^4.0.0"
+                "exit": "0.1.2",
+                "graceful-fs": "4.1.11",
+                "jest-config": "23.6.0",
+                "jest-docblock": "23.2.0",
+                "jest-haste-map": "23.6.0",
+                "jest-jasmine2": "23.6.0",
+                "jest-leak-detector": "23.6.0",
+                "jest-message-util": "23.4.0",
+                "jest-runtime": "23.6.0",
+                "jest-util": "23.4.0",
+                "jest-worker": "23.2.0",
+                "source-map-support": "0.5.9",
+                "throat": "4.1.0"
             },
             "dependencies": {
                 "source-map": {
@@ -3446,8 +3446,8 @@
                     "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
                     "dev": true,
                     "requires": {
-                        "buffer-from": "^1.0.0",
-                        "source-map": "^0.6.0"
+                        "buffer-from": "1.1.1",
+                        "source-map": "0.6.1"
                     }
                 }
             }
@@ -3458,27 +3458,27 @@
             "integrity": "sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==",
             "dev": true,
             "requires": {
-                "babel-core": "^6.0.0",
-                "babel-plugin-istanbul": "^4.1.6",
-                "chalk": "^2.0.1",
-                "convert-source-map": "^1.4.0",
-                "exit": "^0.1.2",
-                "fast-json-stable-stringify": "^2.0.0",
-                "graceful-fs": "^4.1.11",
-                "jest-config": "^23.6.0",
-                "jest-haste-map": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-regex-util": "^23.3.0",
-                "jest-resolve": "^23.6.0",
-                "jest-snapshot": "^23.6.0",
-                "jest-util": "^23.4.0",
-                "jest-validate": "^23.6.0",
-                "micromatch": "^2.3.11",
-                "realpath-native": "^1.0.0",
-                "slash": "^1.0.0",
+                "babel-core": "6.26.3",
+                "babel-plugin-istanbul": "4.1.6",
+                "chalk": "2.4.1",
+                "convert-source-map": "1.6.0",
+                "exit": "0.1.2",
+                "fast-json-stable-stringify": "2.0.0",
+                "graceful-fs": "4.1.11",
+                "jest-config": "23.6.0",
+                "jest-haste-map": "23.6.0",
+                "jest-message-util": "23.4.0",
+                "jest-regex-util": "23.3.0",
+                "jest-resolve": "23.6.0",
+                "jest-snapshot": "23.6.0",
+                "jest-util": "23.4.0",
+                "jest-validate": "23.6.0",
+                "micromatch": "2.3.11",
+                "realpath-native": "1.0.2",
+                "slash": "1.0.0",
                 "strip-bom": "3.0.0",
-                "write-file-atomic": "^2.1.0",
-                "yargs": "^11.0.0"
+                "write-file-atomic": "2.3.0",
+                "yargs": "11.1.0"
             },
             "dependencies": {
                 "strip-bom": {
@@ -3501,16 +3501,16 @@
             "integrity": "sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==",
             "dev": true,
             "requires": {
-                "babel-types": "^6.0.0",
-                "chalk": "^2.0.1",
-                "jest-diff": "^23.6.0",
-                "jest-matcher-utils": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-resolve": "^23.6.0",
-                "mkdirp": "^0.5.1",
-                "natural-compare": "^1.4.0",
-                "pretty-format": "^23.6.0",
-                "semver": "^5.5.0"
+                "babel-types": "6.26.0",
+                "chalk": "2.4.1",
+                "jest-diff": "23.6.0",
+                "jest-matcher-utils": "23.6.0",
+                "jest-message-util": "23.4.0",
+                "jest-resolve": "23.6.0",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "pretty-format": "23.6.0",
+                "semver": "5.5.1"
             }
         },
         "jest-util": {
@@ -3519,14 +3519,14 @@
             "integrity": "sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=",
             "dev": true,
             "requires": {
-                "callsites": "^2.0.0",
-                "chalk": "^2.0.1",
-                "graceful-fs": "^4.1.11",
-                "is-ci": "^1.0.10",
-                "jest-message-util": "^23.4.0",
-                "mkdirp": "^0.5.1",
-                "slash": "^1.0.0",
-                "source-map": "^0.6.0"
+                "callsites": "2.0.0",
+                "chalk": "2.4.1",
+                "graceful-fs": "4.1.11",
+                "is-ci": "1.2.1",
+                "jest-message-util": "23.4.0",
+                "mkdirp": "0.5.1",
+                "slash": "1.0.0",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "callsites": {
@@ -3549,10 +3549,10 @@
             "integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.1",
-                "jest-get-type": "^22.1.0",
-                "leven": "^2.1.0",
-                "pretty-format": "^23.6.0"
+                "chalk": "2.4.1",
+                "jest-get-type": "22.4.3",
+                "leven": "2.1.0",
+                "pretty-format": "23.6.0"
             }
         },
         "jest-watcher": {
@@ -3561,9 +3561,9 @@
             "integrity": "sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=",
             "dev": true,
             "requires": {
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.1",
-                "string-length": "^2.0.0"
+                "ansi-escapes": "3.1.0",
+                "chalk": "2.4.1",
+                "string-length": "2.0.0"
             }
         },
         "jest-worker": {
@@ -3572,7 +3572,7 @@
             "integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
             "dev": true,
             "requires": {
-                "merge-stream": "^1.0.1"
+                "merge-stream": "1.0.1"
             }
         },
         "js-tokens": {
@@ -3587,8 +3587,8 @@
             "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "1.0.10",
+                "esprima": "4.0.1"
             }
         },
         "jsbn": {
@@ -3604,32 +3604,32 @@
             "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
             "dev": true,
             "requires": {
-                "abab": "^2.0.0",
-                "acorn": "^5.5.3",
-                "acorn-globals": "^4.1.0",
-                "array-equal": "^1.0.0",
-                "cssom": ">= 0.3.2 < 0.4.0",
-                "cssstyle": "^1.0.0",
-                "data-urls": "^1.0.0",
-                "domexception": "^1.0.1",
-                "escodegen": "^1.9.1",
-                "html-encoding-sniffer": "^1.0.2",
-                "left-pad": "^1.3.0",
-                "nwsapi": "^2.0.7",
+                "abab": "2.0.0",
+                "acorn": "5.7.3",
+                "acorn-globals": "4.1.0",
+                "array-equal": "1.0.0",
+                "cssom": "0.3.4",
+                "cssstyle": "1.1.1",
+                "data-urls": "1.0.1",
+                "domexception": "1.0.1",
+                "escodegen": "1.11.0",
+                "html-encoding-sniffer": "1.0.2",
+                "left-pad": "1.3.0",
+                "nwsapi": "2.0.9",
                 "parse5": "4.0.0",
-                "pn": "^1.1.0",
-                "request": "^2.87.0",
-                "request-promise-native": "^1.0.5",
-                "sax": "^1.2.4",
-                "symbol-tree": "^3.2.2",
-                "tough-cookie": "^2.3.4",
-                "w3c-hr-time": "^1.0.1",
-                "webidl-conversions": "^4.0.2",
-                "whatwg-encoding": "^1.0.3",
-                "whatwg-mimetype": "^2.1.0",
-                "whatwg-url": "^6.4.1",
-                "ws": "^5.2.0",
-                "xml-name-validator": "^3.0.0"
+                "pn": "1.1.0",
+                "request": "2.88.0",
+                "request-promise-native": "1.0.5",
+                "sax": "1.2.4",
+                "symbol-tree": "3.2.2",
+                "tough-cookie": "2.4.3",
+                "w3c-hr-time": "1.0.1",
+                "webidl-conversions": "4.0.2",
+                "whatwg-encoding": "1.0.4",
+                "whatwg-mimetype": "2.1.0",
+                "whatwg-url": "6.5.0",
+                "ws": "5.2.2",
+                "xml-name-validator": "3.0.0"
             }
         },
         "jsesc": {
@@ -3686,7 +3686,7 @@
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "dev": true,
             "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
             }
         },
         "kleur": {
@@ -3701,7 +3701,7 @@
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "dev": true,
             "requires": {
-                "invert-kv": "^1.0.0"
+                "invert-kv": "1.0.0"
             }
         },
         "lcov-parse": {
@@ -3728,8 +3728,8 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
             }
         },
         "load-json-file": {
@@ -3738,11 +3738,11 @@
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0",
-                "strip-bom": "^2.0.0"
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0"
             }
         },
         "locate-path": {
@@ -3751,8 +3751,8 @@
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
-                "p-locate": "^2.0.0",
-                "path-exists": "^3.0.0"
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
             }
         },
         "lodash": {
@@ -3779,7 +3779,7 @@
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
             "dev": true,
             "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
+                "js-tokens": "3.0.2"
             }
         },
         "lru-cache": {
@@ -3788,8 +3788,8 @@
             "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
             "dev": true,
             "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
             }
         },
         "makeerror": {
@@ -3798,7 +3798,7 @@
             "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
             "dev": true,
             "requires": {
-                "tmpl": "1.0.x"
+                "tmpl": "1.0.4"
             }
         },
         "map-cache": {
@@ -3813,7 +3813,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "^1.0.0"
+                "object-visit": "1.0.1"
             }
         },
         "math-random": {
@@ -3828,7 +3828,7 @@
             "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
             "dev": true,
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "mimic-fn": "1.2.0"
             }
         },
         "merge": {
@@ -3843,7 +3843,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.1"
+                "readable-stream": "2.3.6"
             }
         },
         "micromatch": {
@@ -3852,19 +3852,19 @@
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
-                "arr-diff": "^2.0.0",
-                "array-unique": "^0.2.1",
-                "braces": "^1.8.2",
-                "expand-brackets": "^0.1.4",
-                "extglob": "^0.3.1",
-                "filename-regex": "^2.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.1",
-                "kind-of": "^3.0.2",
-                "normalize-path": "^2.0.1",
-                "object.omit": "^2.0.0",
-                "parse-glob": "^3.0.4",
-                "regex-cache": "^0.4.2"
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.4"
             }
         },
         "mime-db": {
@@ -3879,7 +3879,7 @@
             "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
             "dev": true,
             "requires": {
-                "mime-db": "~1.36.0"
+                "mime-db": "1.36.0"
             }
         },
         "mimic-fn": {
@@ -3894,7 +3894,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
             }
         },
         "minimist": {
@@ -3909,8 +3909,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "^1.0.2",
-                "is-extendable": "^1.0.1"
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -3919,7 +3919,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 }
             }
@@ -3966,17 +3966,17 @@
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
             "dev": true,
             "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "fragment-cache": "^0.2.1",
-                "is-windows": "^1.0.2",
-                "kind-of": "^6.0.2",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "fragment-cache": "0.2.1",
+                "is-windows": "1.0.2",
+                "kind-of": "6.0.2",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -4017,10 +4017,10 @@
             "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
             "dev": true,
             "requires": {
-                "growly": "^1.3.0",
-                "semver": "^5.4.1",
-                "shellwords": "^0.1.1",
-                "which": "^1.3.0"
+                "growly": "1.3.0",
+                "semver": "5.5.1",
+                "shellwords": "0.1.1",
+                "which": "1.3.1"
             }
         },
         "normalize-package-data": {
@@ -4029,10 +4029,10 @@
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
+                "hosted-git-info": "2.7.1",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.5.1",
+                "validate-npm-package-license": "3.0.4"
             }
         },
         "normalize-path": {
@@ -4041,7 +4041,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "^1.0.1"
+                "remove-trailing-separator": "1.1.0"
             }
         },
         "npm-run-path": {
@@ -4050,7 +4050,7 @@
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
             "requires": {
-                "path-key": "^2.0.0"
+                "path-key": "2.0.1"
             }
         },
         "number-is-nan": {
@@ -4083,9 +4083,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "^0.1.0",
-                "define-property": "^0.2.5",
-                "kind-of": "^3.0.3"
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "define-property": {
@@ -4094,7 +4094,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 }
             }
@@ -4111,7 +4111,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.0"
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -4128,8 +4128,8 @@
             "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "es-abstract": "^1.5.1"
+                "define-properties": "1.1.3",
+                "es-abstract": "1.12.0"
             }
         },
         "object.omit": {
@@ -4138,8 +4138,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "^0.1.4",
-                "is-extendable": "^0.1.1"
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
             }
         },
         "object.pick": {
@@ -4148,7 +4148,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -4165,7 +4165,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
             }
         },
         "onetime": {
@@ -4174,7 +4174,7 @@
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "mimic-fn": "1.2.0"
             }
         },
         "optimist": {
@@ -4183,8 +4183,8 @@
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
             },
             "dependencies": {
                 "minimist": {
@@ -4207,12 +4207,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.4",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "wordwrap": "~1.0.0"
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
             }
         },
         "os-homedir": {
@@ -4227,9 +4227,9 @@
             "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
             "dev": true,
             "requires": {
-                "execa": "^0.7.0",
-                "lcid": "^1.0.0",
-                "mem": "^1.1.0"
+                "execa": "0.7.0",
+                "lcid": "1.0.0",
+                "mem": "1.1.0"
             }
         },
         "os-tmpdir": {
@@ -4250,7 +4250,7 @@
             "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
             "dev": true,
             "requires": {
-                "p-try": "^1.0.0"
+                "p-try": "1.0.0"
             }
         },
         "p-locate": {
@@ -4259,7 +4259,7 @@
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "dev": true,
             "requires": {
-                "p-limit": "^1.1.0"
+                "p-limit": "1.3.0"
             }
         },
         "p-try": {
@@ -4274,10 +4274,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
             }
         },
         "parse-json": {
@@ -4286,7 +4286,7 @@
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "^1.2.0"
+                "error-ex": "1.3.2"
             }
         },
         "parse5": {
@@ -4337,9 +4337,9 @@
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "graceful-fs": "4.1.11",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
             }
         },
         "performance-now": {
@@ -4366,7 +4366,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "^2.0.0"
+                "pinkie": "2.0.4"
             }
         },
         "pkg-dir": {
@@ -4375,7 +4375,7 @@
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "dev": true,
             "requires": {
-                "find-up": "^2.1.0"
+                "find-up": "2.1.0"
             }
         },
         "pluralize": {
@@ -4414,8 +4414,8 @@
             "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
             "dev": true,
             "requires": {
-                "ansi-regex": "^3.0.0",
-                "ansi-styles": "^3.2.0"
+                "ansi-regex": "3.0.0",
+                "ansi-styles": "3.2.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -4430,7 +4430,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.3"
                     }
                 }
             }
@@ -4459,8 +4459,8 @@
             "integrity": "sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==",
             "dev": true,
             "requires": {
-                "kleur": "^2.0.1",
-                "sisteransi": "^0.1.1"
+                "kleur": "2.0.2",
+                "sisteransi": "0.1.1"
             }
         },
         "pseudomap": {
@@ -4493,9 +4493,9 @@
             "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
             "dev": true,
             "requires": {
-                "is-number": "^4.0.0",
-                "kind-of": "^6.0.0",
-                "math-random": "^1.0.1"
+                "is-number": "4.0.0",
+                "kind-of": "6.0.2",
+                "math-random": "1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -4518,9 +4518,9 @@
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "dev": true,
             "requires": {
-                "load-json-file": "^1.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^1.0.0"
+                "load-json-file": "1.1.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "1.1.0"
             }
         },
         "read-pkg-up": {
@@ -4529,8 +4529,8 @@
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "dev": true,
             "requires": {
-                "find-up": "^1.0.0",
-                "read-pkg": "^1.0.0"
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
             },
             "dependencies": {
                 "find-up": {
@@ -4539,8 +4539,8 @@
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "dev": true,
                     "requires": {
-                        "path-exists": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
+                        "path-exists": "2.1.0",
+                        "pinkie-promise": "2.0.1"
                     }
                 },
                 "path-exists": {
@@ -4549,7 +4549,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "^2.0.0"
+                        "pinkie-promise": "2.0.1"
                     }
                 }
             }
@@ -4560,13 +4560,13 @@
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
             }
         },
         "realpath-native": {
@@ -4575,7 +4575,7 @@
             "integrity": "sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==",
             "dev": true,
             "requires": {
-                "util.promisify": "^1.0.0"
+                "util.promisify": "1.0.0"
             }
         },
         "regenerator-runtime": {
@@ -4590,7 +4590,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "^0.1.3"
+                "is-equal-shallow": "0.1.3"
             }
         },
         "regex-not": {
@@ -4599,8 +4599,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^3.0.2",
-                "safe-regex": "^1.1.0"
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
             }
         },
         "regexpp": {
@@ -4633,7 +4633,7 @@
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
-                "is-finite": "^1.0.0"
+                "is-finite": "1.0.2"
             }
         },
         "request": {
@@ -4642,26 +4642,26 @@
             "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "dev": true,
             "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
+                "aws-sign2": "0.7.0",
+                "aws4": "1.8.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.6",
+                "extend": "3.0.2",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.2",
+                "har-validator": "5.1.0",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.20",
+                "oauth-sign": "0.9.0",
+                "performance-now": "2.1.0",
+                "qs": "6.5.2",
+                "safe-buffer": "5.1.2",
+                "tough-cookie": "2.4.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.3.2"
             }
         },
         "request-promise-core": {
@@ -4670,7 +4670,7 @@
             "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
             "dev": true,
             "requires": {
-                "lodash": "^4.13.1"
+                "lodash": "4.17.11"
             }
         },
         "request-promise-native": {
@@ -4680,8 +4680,8 @@
             "dev": true,
             "requires": {
                 "request-promise-core": "1.1.1",
-                "stealthy-require": "^1.1.0",
-                "tough-cookie": ">=2.3.3"
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.4.3"
             }
         },
         "require-directory": {
@@ -4702,8 +4702,8 @@
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "dev": true,
             "requires": {
-                "caller-path": "^0.1.0",
-                "resolve-from": "^1.0.0"
+                "caller-path": "0.1.0",
+                "resolve-from": "1.0.1"
             }
         },
         "resolve": {
@@ -4718,7 +4718,7 @@
             "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
             "dev": true,
             "requires": {
-                "resolve-from": "^3.0.0"
+                "resolve-from": "3.0.0"
             },
             "dependencies": {
                 "resolve-from": {
@@ -4747,8 +4747,8 @@
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "onetime": "^2.0.0",
-                "signal-exit": "^3.0.2"
+                "onetime": "2.0.1",
+                "signal-exit": "3.0.2"
             }
         },
         "ret": {
@@ -4763,7 +4763,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "^7.0.5"
+                "glob": "7.1.3"
             }
         },
         "rsvp": {
@@ -4778,7 +4778,7 @@
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "is-promise": "^2.1.0"
+                "is-promise": "2.1.0"
             }
         },
         "rx-lite": {
@@ -4793,7 +4793,7 @@
             "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
             "dev": true,
             "requires": {
-                "rx-lite": "*"
+                "rx-lite": "4.0.8"
             }
         },
         "safe-buffer": {
@@ -4808,7 +4808,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "~0.1.10"
+                "ret": "0.1.15"
             }
         },
         "safer-buffer": {
@@ -4823,15 +4823,15 @@
             "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
             "dev": true,
             "requires": {
-                "anymatch": "^2.0.0",
-                "capture-exit": "^1.2.0",
-                "exec-sh": "^0.2.0",
-                "fb-watchman": "^2.0.0",
-                "fsevents": "^1.2.3",
-                "micromatch": "^3.1.4",
-                "minimist": "^1.1.1",
-                "walker": "~1.0.5",
-                "watch": "~0.18.0"
+                "anymatch": "2.0.0",
+                "capture-exit": "1.2.0",
+                "exec-sh": "0.2.2",
+                "fb-watchman": "2.0.0",
+                "fsevents": "1.2.4",
+                "micromatch": "3.1.10",
+                "minimist": "1.2.0",
+                "walker": "1.0.7",
+                "watch": "0.18.0"
             },
             "dependencies": {
                 "arr-diff": {
@@ -4852,16 +4852,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
+                        "arr-flatten": "1.1.0",
+                        "array-unique": "0.3.2",
+                        "extend-shallow": "2.0.1",
+                        "fill-range": "4.0.0",
+                        "isobject": "3.0.1",
+                        "repeat-element": "1.1.3",
+                        "snapdragon": "0.8.2",
+                        "snapdragon-node": "2.1.1",
+                        "split-string": "3.1.0",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -4870,7 +4870,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -4890,13 +4890,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "^2.3.3",
-                        "define-property": "^0.2.5",
-                        "extend-shallow": "^2.0.1",
-                        "posix-character-classes": "^0.1.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
+                        "debug": "2.6.9",
+                        "define-property": "0.2.5",
+                        "extend-shallow": "2.0.1",
+                        "posix-character-classes": "0.1.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "define-property": {
@@ -4905,7 +4905,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^0.1.0"
+                                "is-descriptor": "0.1.6"
                             }
                         },
                         "extend-shallow": {
@@ -4914,7 +4914,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -4923,7 +4923,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "^3.0.2"
+                                "kind-of": "3.2.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -4932,7 +4932,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "^1.1.5"
+                                        "is-buffer": "1.1.6"
                                     }
                                 }
                             }
@@ -4943,7 +4943,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "^3.0.2"
+                                "kind-of": "3.2.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -4952,7 +4952,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "^1.1.5"
+                                        "is-buffer": "1.1.6"
                                     }
                                 }
                             }
@@ -4963,9 +4963,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "^0.1.6",
-                                "is-data-descriptor": "^0.1.4",
-                                "kind-of": "^5.0.0"
+                                "is-accessor-descriptor": "0.1.6",
+                                "is-data-descriptor": "0.1.4",
+                                "kind-of": "5.1.0"
                             }
                         },
                         "kind-of": {
@@ -4982,14 +4982,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "^0.3.2",
-                        "define-property": "^1.0.0",
-                        "expand-brackets": "^2.1.4",
-                        "extend-shallow": "^2.0.1",
-                        "fragment-cache": "^0.2.1",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
+                        "array-unique": "0.3.2",
+                        "define-property": "1.0.0",
+                        "expand-brackets": "2.1.4",
+                        "extend-shallow": "2.0.1",
+                        "fragment-cache": "0.2.1",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     },
                     "dependencies": {
                         "define-property": {
@@ -4998,7 +4998,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "^1.0.0"
+                                "is-descriptor": "1.0.2"
                             }
                         },
                         "extend-shallow": {
@@ -5007,7 +5007,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -5018,10 +5018,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
+                        "extend-shallow": "2.0.1",
+                        "is-number": "3.0.0",
+                        "repeat-string": "1.6.1",
+                        "to-regex-range": "2.1.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -5030,7 +5030,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "^0.1.0"
+                                "is-extendable": "0.1.1"
                             }
                         }
                     }
@@ -5041,7 +5041,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -5050,7 +5050,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -5059,9 +5059,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-number": {
@@ -5070,7 +5070,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -5079,7 +5079,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "^1.1.5"
+                                "is-buffer": "1.1.6"
                             }
                         }
                     }
@@ -5102,19 +5102,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "braces": "^2.3.1",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "extglob": "^2.0.4",
-                        "fragment-cache": "^0.2.1",
-                        "kind-of": "^6.0.2",
-                        "nanomatch": "^1.2.9",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.2"
+                        "arr-diff": "4.0.0",
+                        "array-unique": "0.3.2",
+                        "braces": "2.3.2",
+                        "define-property": "2.0.2",
+                        "extend-shallow": "3.0.2",
+                        "extglob": "2.0.4",
+                        "fragment-cache": "0.2.1",
+                        "kind-of": "6.0.2",
+                        "nanomatch": "1.2.13",
+                        "object.pick": "1.3.0",
+                        "regex-not": "1.0.2",
+                        "snapdragon": "0.8.2",
+                        "to-regex": "3.0.2"
                     }
                 },
                 "ms": {
@@ -5149,10 +5149,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.3",
-                "split-string": "^3.0.1"
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -5161,7 +5161,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -5172,7 +5172,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "^1.0.0"
+                "shebang-regex": "1.0.0"
             }
         },
         "shebang-regex": {
@@ -5211,7 +5211,7 @@
             "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "^2.0.0"
+                "is-fullwidth-code-point": "2.0.0"
             }
         },
         "snapdragon": {
@@ -5220,14 +5220,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "^0.11.1",
-                "debug": "^2.2.0",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "map-cache": "^0.2.2",
-                "source-map": "^0.5.6",
-                "source-map-resolve": "^0.5.0",
-                "use": "^3.1.0"
+                "base": "0.11.2",
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.2",
+                "use": "3.1.1"
             },
             "dependencies": {
                 "debug": {
@@ -5245,7 +5245,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "extend-shallow": {
@@ -5254,7 +5254,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "ms": {
@@ -5271,9 +5271,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.0",
-                "snapdragon-util": "^3.0.1"
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -5282,7 +5282,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -5291,7 +5291,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -5300,7 +5300,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -5309,9 +5309,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 },
                 "isobject": {
@@ -5334,7 +5334,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "^3.2.0"
+                "kind-of": "3.2.2"
             }
         },
         "source-map": {
@@ -5349,11 +5349,11 @@
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "^2.1.1",
-                "decode-uri-component": "^0.2.0",
-                "resolve-url": "^0.2.1",
-                "source-map-url": "^0.4.0",
-                "urix": "^0.1.0"
+                "atob": "2.1.2",
+                "decode-uri-component": "0.2.0",
+                "resolve-url": "0.2.1",
+                "source-map-url": "0.4.0",
+                "urix": "0.1.0"
             }
         },
         "source-map-support": {
@@ -5362,7 +5362,7 @@
             "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
             "dev": true,
             "requires": {
-                "source-map": "^0.5.6"
+                "source-map": "0.5.7"
             }
         },
         "source-map-url": {
@@ -5377,8 +5377,8 @@
             "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
             "dev": true,
             "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.1"
             }
         },
         "spdx-exceptions": {
@@ -5393,8 +5393,8 @@
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
+                "spdx-exceptions": "2.1.0",
+                "spdx-license-ids": "3.0.1"
             }
         },
         "spdx-license-ids": {
@@ -5409,7 +5409,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^3.0.0"
+                "extend-shallow": "3.0.2"
             }
         },
         "sprintf-js": {
@@ -5424,15 +5424,15 @@
             "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
             "dev": true,
             "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
+                "asn1": "0.2.4",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.2",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.2",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2",
+                "tweetnacl": "0.14.5"
             }
         },
         "stack-utils": {
@@ -5447,8 +5447,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "^0.2.5",
-                "object-copy": "^0.1.0"
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -5457,7 +5457,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 }
             }
@@ -5474,8 +5474,8 @@
             "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
             "dev": true,
             "requires": {
-                "astral-regex": "^1.0.0",
-                "strip-ansi": "^4.0.0"
+                "astral-regex": "1.0.0",
+                "strip-ansi": "4.0.0"
             }
         },
         "string-width": {
@@ -5484,8 +5484,8 @@
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
             }
         },
         "string_decoder": {
@@ -5494,7 +5494,7 @@
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
             }
         },
         "strip-ansi": {
@@ -5503,7 +5503,7 @@
             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -5520,7 +5520,7 @@
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
             "requires": {
-                "is-utf8": "^0.2.0"
+                "is-utf8": "0.2.1"
             }
         },
         "strip-eof": {
@@ -5553,12 +5553,12 @@
             "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
             "dev": true,
             "requires": {
-                "ajv": "^5.2.3",
-                "ajv-keywords": "^2.1.0",
-                "chalk": "^2.1.0",
-                "lodash": "^4.17.4",
+                "ajv": "5.5.2",
+                "ajv-keywords": "2.1.1",
+                "chalk": "2.4.1",
+                "lodash": "4.17.11",
                 "slice-ansi": "1.0.0",
-                "string-width": "^2.1.1"
+                "string-width": "2.1.1"
             }
         },
         "task-easy": {
@@ -5572,11 +5572,11 @@
             "integrity": "sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==",
             "dev": true,
             "requires": {
-                "arrify": "^1.0.1",
-                "micromatch": "^2.3.11",
-                "object-assign": "^4.1.0",
-                "read-pkg-up": "^1.0.1",
-                "require-main-filename": "^1.0.1"
+                "arrify": "1.0.1",
+                "micromatch": "2.3.11",
+                "object-assign": "4.1.1",
+                "read-pkg-up": "1.0.1",
+                "require-main-filename": "1.0.1"
             }
         },
         "text-table": {
@@ -5603,7 +5603,7 @@
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
             "dev": true,
             "requires": {
-                "os-tmpdir": "~1.0.2"
+                "os-tmpdir": "1.0.2"
             }
         },
         "tmpl": {
@@ -5624,7 +5624,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             }
         },
         "to-regex": {
@@ -5633,10 +5633,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "regex-not": "^1.0.2",
-                "safe-regex": "^1.1.0"
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "regex-not": "1.0.2",
+                "safe-regex": "1.1.0"
             }
         },
         "to-regex-range": {
@@ -5645,8 +5645,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1"
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
             },
             "dependencies": {
                 "is-number": {
@@ -5655,7 +5655,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^3.0.2"
+                        "kind-of": "3.2.2"
                     }
                 }
             }
@@ -5666,8 +5666,8 @@
             "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
             "dev": true,
             "requires": {
-                "psl": "^1.1.24",
-                "punycode": "^1.4.1"
+                "psl": "1.1.29",
+                "punycode": "1.4.1"
             }
         },
         "tr46": {
@@ -5676,7 +5676,7 @@
             "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
             "dev": true,
             "requires": {
-                "punycode": "^2.1.0"
+                "punycode": "2.1.1"
             },
             "dependencies": {
                 "punycode": {
@@ -5699,7 +5699,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "tweetnacl": {
@@ -5715,7 +5715,7 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "~1.1.2"
+                "prelude-ls": "1.1.2"
             }
         },
         "typedarray": {
@@ -5731,8 +5731,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "commander": "~2.17.1",
-                "source-map": "~0.6.1"
+                "commander": "2.17.1",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -5750,10 +5750,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "^3.1.0",
-                "get-value": "^2.0.6",
-                "is-extendable": "^0.1.1",
-                "set-value": "^0.4.3"
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -5762,7 +5762,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "set-value": {
@@ -5771,10 +5771,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-extendable": "^0.1.1",
-                        "is-plain-object": "^2.0.1",
-                        "to-object-path": "^0.3.0"
+                        "extend-shallow": "2.0.1",
+                        "is-extendable": "0.1.1",
+                        "is-plain-object": "2.0.4",
+                        "to-object-path": "0.3.0"
                     }
                 }
             }
@@ -5785,8 +5785,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "^0.3.1",
-                "isobject": "^3.0.0"
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "has-value": {
@@ -5795,9 +5795,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "^2.0.3",
-                        "has-values": "^0.1.4",
-                        "isobject": "^2.0.0"
+                        "get-value": "2.0.6",
+                        "has-values": "0.1.4",
+                        "isobject": "2.1.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -5849,8 +5849,8 @@
             "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "object.getownpropertydescriptors": "^2.0.3"
+                "define-properties": "1.1.3",
+                "object.getownpropertydescriptors": "2.0.3"
             }
         },
         "uuid": {
@@ -5865,8 +5865,8 @@
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
             "dev": true,
             "requires": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
+                "spdx-correct": "3.0.0",
+                "spdx-expression-parse": "3.0.0"
             }
         },
         "verror": {
@@ -5875,9 +5875,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0",
+                "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
+                "extsprintf": "1.3.0"
             }
         },
         "w3c-hr-time": {
@@ -5886,7 +5886,7 @@
             "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
             "dev": true,
             "requires": {
-                "browser-process-hrtime": "^0.1.2"
+                "browser-process-hrtime": "0.1.2"
             }
         },
         "walker": {
@@ -5895,7 +5895,7 @@
             "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
             "dev": true,
             "requires": {
-                "makeerror": "1.0.x"
+                "makeerror": "1.0.11"
             }
         },
         "watch": {
@@ -5904,8 +5904,8 @@
             "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
             "dev": true,
             "requires": {
-                "exec-sh": "^0.2.0",
-                "minimist": "^1.2.0"
+                "exec-sh": "0.2.2",
+                "minimist": "1.2.0"
             }
         },
         "webidl-conversions": {
@@ -5929,7 +5929,7 @@
                     "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
                     "dev": true,
                     "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
+                        "safer-buffer": "2.1.2"
                     }
                 }
             }
@@ -5946,9 +5946,9 @@
             "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
             "dev": true,
             "requires": {
-                "lodash.sortby": "^4.7.0",
-                "tr46": "^1.0.1",
-                "webidl-conversions": "^4.0.2"
+                "lodash.sortby": "4.7.0",
+                "tr46": "1.0.1",
+                "webidl-conversions": "4.0.2"
             }
         },
         "which": {
@@ -5957,7 +5957,7 @@
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
             }
         },
         "which-module": {
@@ -5978,8 +5978,8 @@
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
             },
             "dependencies": {
                 "is-fullwidth-code-point": {
@@ -5988,7 +5988,7 @@
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                     }
                 },
                 "string-width": {
@@ -5997,9 +5997,9 @@
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
                     "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                     }
                 },
                 "strip-ansi": {
@@ -6008,7 +6008,7 @@
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 }
             }
@@ -6025,7 +6025,7 @@
             "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
             "dev": true,
             "requires": {
-                "mkdirp": "^0.5.1"
+                "mkdirp": "0.5.1"
             }
         },
         "write-file-atomic": {
@@ -6034,9 +6034,9 @@
             "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.11",
-                "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.2"
+                "graceful-fs": "4.1.11",
+                "imurmurhash": "0.1.4",
+                "signal-exit": "3.0.2"
             }
         },
         "ws": {
@@ -6045,7 +6045,7 @@
             "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
             "dev": true,
             "requires": {
-                "async-limiter": "~1.0.0"
+                "async-limiter": "1.0.0"
             }
         },
         "xml-name-validator": {
@@ -6072,18 +6072,18 @@
             "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
             "dev": true,
             "requires": {
-                "cliui": "^4.0.0",
-                "decamelize": "^1.1.1",
-                "find-up": "^2.1.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^2.0.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^9.0.2"
+                "cliui": "4.1.0",
+                "decamelize": "1.2.0",
+                "find-up": "2.1.0",
+                "get-caller-file": "1.0.3",
+                "os-locale": "2.1.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "9.0.2"
             }
         },
         "yargs-parser": {
@@ -6092,7 +6092,7 @@
             "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
             "dev": true,
             "requires": {
-                "camelcase": "^4.1.0"
+                "camelcase": "4.1.0"
             }
         }
     }

--- a/src/enip/encapsulation/__snapshots__/encapsulation.spec.js.snap
+++ b/src/enip/encapsulation/__snapshots__/encapsulation.spec.js.snap
@@ -217,6 +217,70 @@ Array [
 ]
 `;
 
+exports[`Encapsulation Test Encapsulation Generator Functions ListIdentity Returns Correct Encapsulation String 1`] = `
+Object {
+  "data": Array [
+    99,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  ],
+  "type": "Buffer",
+}
+`;
+
+exports[`Encapsulation Test Encapsulation Generator Functions ListServices Returns Correct Encapsulation String 1`] = `
+Object {
+  "data": Array [
+    4,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  ],
+  "type": "Buffer",
+}
+`;
+
 exports[`Encapsulation Test Encapsulation Generator Functions Register Session Returns Correct Encapsulation String 1`] = `
 Object {
   "data": Array [

--- a/src/enip/encapsulation/encapsulation.spec.js
+++ b/src/enip/encapsulation/encapsulation.spec.js
@@ -70,7 +70,7 @@ describe("Encapsulation", () => {
     });
 
     describe("Test Encapsulation Generator Functions", () => {
-        const { registerSession, unregisterSession, sendRRData, sendUnitData } = encapsulation;
+        const { registerSession, unregisterSession, sendRRData, sendUnitData, listIdentity, listServices } = encapsulation;
 
         it("Register Session Returns Correct Encapsulation String", () => {
             const data = registerSession();
@@ -92,6 +92,18 @@ describe("Encapsulation", () => {
 
         it("SendUnitData Returns Correct Encapsulation String", () => {
             const data = sendUnitData(98705, Buffer.from("hello world"), 32145, 456);
+
+            expect(data).toMatchSnapshot();
+        });
+
+        it("ListIdentity Returns Correct Encapsulation String", () => {
+            const data = listIdentity();
+
+            expect(data).toMatchSnapshot();
+        });
+
+        it("ListServices Returns Correct Encapsulation String", () => {
+            const data = listServices();
 
             expect(data).toMatchSnapshot();
         });

--- a/src/enip/encapsulation/index.js
+++ b/src/enip/encapsulation/index.js
@@ -298,6 +298,19 @@ const listIdentity = () => {
 };
 
 /**
+ * Returns a ListServices String
+ *
+ * @returns {string} ListServices string
+ */
+const listServices = () => {
+    const { ListServices} = commands;
+    const { build } = header;
+
+    // Build ListServices Buffer
+    return build(ListServices, 0x00);
+};
+
+/**
  * Returns a UCMM Encapsulated Packet String
  *
  * @param {number} session - Encapsulation Session ID
@@ -375,5 +388,6 @@ module.exports = {
     unregisterSession,
     sendRRData,
     sendUnitData,
-    listIdentity
+    listIdentity,
+    listServices
 };

--- a/src/enip/encapsulation/index.js
+++ b/src/enip/encapsulation/index.js
@@ -285,6 +285,19 @@ const unregisterSession = session => {
 };
 
 /**
+ * Returns a ListIdentity String
+ *
+ * @returns {string} listIdentity string
+ */
+const listIdentity = () => {
+    const { ListIdentity } = commands;
+    const { build } = header;
+
+    // Build ListIdentity Buffer
+    return build(ListIdentity, 0x00);
+};
+
+/**
  * Returns a UCMM Encapsulated Packet String
  *
  * @param {number} session - Encapsulation Session ID
@@ -361,5 +374,6 @@ module.exports = {
     registerSession,
     unregisterSession,
     sendRRData,
-    sendUnitData
+    sendUnitData,
+    listIdentity
 };

--- a/src/enip/index.js
+++ b/src/enip/index.js
@@ -28,7 +28,7 @@ class ENIP extends Socket {
             error: { code: null, msg: null }
         };
 
-        this.properties = { 
+        this.plcProperties = { 
             vendorID: null,
             deviceType: null,
             productCode: null,
@@ -237,25 +237,25 @@ class ENIP extends Socket {
         );
 
         let ptr = 24; // Other data is not relevant.
-        this.properties.vendorID = listData.readUInt16LE(ptr);
+        this.plcProperties.vendorID = listData.readUInt16LE(ptr);
         ptr+=2;
-        this.properties.deviceType = listData.readUInt16LE(ptr);
+        this.plcProperties.deviceType = listData.readUInt16LE(ptr);
         ptr+=2;
-        this.properties.productCode = listData.readUInt16LE(ptr);
+        this.plcProperties.productCode = listData.readUInt16LE(ptr);
         ptr+=2;
-        this.properties.majorRevision = listData.readUInt8(ptr);
+        this.plcProperties.majorRevision = listData.readUInt8(ptr);
         ptr+=1;
-        this.properties.minorRevision = listData.readUInt8(ptr);
+        this.plcProperties.minorRevision = listData.readUInt8(ptr);
         ptr+=1;
-        this.properties.status = listData.readUInt16LE(ptr);
+        this.plcProperties.status = listData.readUInt16LE(ptr);
         ptr+=2;
-        this.properties.serialNumber = listData.readUInt32LE(ptr);
+        this.plcProperties.serialNumber = listData.readUInt32LE(ptr);
         ptr+=4;
-        this.properties.productNameLength = listData.readUInt8(ptr);
+        this.plcProperties.productNameLength = listData.readUInt8(ptr);
         ptr+=1;
-        this.properties.productName = listData.toString("ascii",ptr,listData.length-1);
-        ptr+=this.properties.productNameLength;
-        this.properties.state = listData.readUInt8(ptr);
+        this.plcProperties.productName = listData.toString("ascii",ptr,listData.length-1);
+        ptr+=this.plcProperties.productNameLength;
+        this.plcProperties.state = listData.readUInt8(ptr);
 
         // Clean Up Local Listeners
         this.removeAllListeners("ListIdentity Received");
@@ -266,7 +266,7 @@ class ENIP extends Socket {
         this.state.TCP.establishing = false;
         this.state.TCP.established = false;
 
-        return this.properties;
+        return this.plcProperties;
     }
 
     /**

--- a/src/enip/index.js
+++ b/src/enip/index.js
@@ -236,7 +236,21 @@ class ENIP extends Socket {
             listIdentityErr
         );
 
-        let ptr = 24; // Other data is not relevant.
+        let ptr = 8; // Starting with Socket Address
+        this.plcProperties.socketAddress = {};
+        this.plcProperties.socketAddress.sin_family = listData.readUInt16BE(ptr);
+        ptr+=2;
+        this.plcProperties.socketAddress.sin_port = listData.readUInt16BE(ptr);
+        ptr+=2;
+        this.plcProperties.socketAddress.sin_addr = listData.readUInt8(ptr).toString()+
+        "."+listData.readUInt8(ptr+1).toString()+
+        "."+listData.readUInt8(ptr+2).toString()+
+        "."+listData.readUInt8(ptr+3).toString(); 
+        ptr+=4;
+        this.plcProperties.socketAddress.sin_zero = 0;
+        ptr+=8;
+
+        // Now follows the asset data
         this.plcProperties.vendorID = listData.readUInt16LE(ptr);
         ptr+=2;
         this.plcProperties.deviceType = listData.readUInt16LE(ptr);

--- a/src/index.js
+++ b/src/index.js
@@ -4,4 +4,10 @@ const TagGroup = require("./tag-group");
 const EthernetIP = require("./enip");
 const util = require("./utilities");
 
+const mynip = new EthernetIP.ENIP();
+mynip.listIdentities("192.168.1.11").then(data =>{
+    if(data) {
+        console.log(data);
+    }
+});
 module.exports = { Controller, Tag, TagGroup, EthernetIP, util };

--- a/src/index.js
+++ b/src/index.js
@@ -4,10 +4,13 @@ const TagGroup = require("./tag-group");
 const EthernetIP = require("./enip");
 const util = require("./utilities");
 
-const mynip = new EthernetIP.ENIP();
-mynip.listServices("192.168.1.11").then(data =>{
+/*const mynip = new EthernetIP.ENIP();
+mynip.listServices("192.168.1.11").then(data => {
     if(data) {
         console.log(data);
     }
+});*/
+util.discover((enipList) => {
+    console.log(enipList);
 });
 module.exports = { Controller, Tag, TagGroup, EthernetIP, util };

--- a/src/index.js
+++ b/src/index.js
@@ -4,18 +4,4 @@ const TagGroup = require("./tag-group");
 const EthernetIP = require("./enip");
 const util = require("./utilities");
 
-/*const mynip = new EthernetIP.ENIP();
-mynip.listServices("192.168.1.11").then(data => {
-    if(data) {
-        console.log(data);
-    }
-});*/
-util.discoverProm()
-    .then((ret) =>{
-        console.log(ret);
-    })
-    .catch((err) =>{
-        console.log(err);
-    });
-
 module.exports = { Controller, Tag, TagGroup, EthernetIP, util };

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,12 @@ mynip.listServices("192.168.1.11").then(data => {
         console.log(data);
     }
 });*/
-util.discover((enipList) => {
-    console.log(enipList);
-});
+util.discoverProm()
+    .then((ret) =>{
+        console.log(ret);
+    })
+    .catch((err) =>{
+        console.log(err);
+    });
+
 module.exports = { Controller, Tag, TagGroup, EthernetIP, util };

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ const EthernetIP = require("./enip");
 const util = require("./utilities");
 
 const mynip = new EthernetIP.ENIP();
-mynip.listIdentities("192.168.1.11").then(data =>{
+mynip.listServices("192.168.1.11").then(data =>{
     if(data) {
         console.log(data);
     }

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -30,15 +30,14 @@ const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
  * Sends a broadcast to a specified IPv4 Interface in order to discover all present EthernetIP
  * devices. If no interface is specified, checks all available interfaces and sends a broadcast to them.
  *
- * @override
  * @param {string} IPv4Interface - The interface we want to check the PLCs of, if not specified, all interfaces will be checked
  * @param {function} cb - The callback that is to be executed after the search is finished
- * @returns {Promise}
- * @memberof ENIP
+ * @memberof Utilities
  */
 function discover(cb,IPv4Interface = undefined) {
     const ENIPList = new Array();
     const IPv4List = new Array();
+    /* No specified interface means we need to discover them on our own */
     if(IPv4Interface == undefined) {
         const interfaceList = os.networkInterfaces();
         const iFaceListKeys = Object.keys(interfaceList);
@@ -52,11 +51,13 @@ function discover(cb,IPv4Interface = undefined) {
             }
         }
     }
+    /* An interface has been specified! */
     else {
         const IPv4RegEx = new RegExp("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$");
         if (!IPv4RegEx.test(IPv4Interface)) throw new Error("Interface must match IPv4 format!");
         IPv4List.push({address: IPv4Interface});    
     }
+    /* For each interface, we send a broadcast with a listIdentity command */
     for (const addresses of IPv4List) {
         let dsock = dgram.createSocket("udp4");
         dsock.bind(0,addresses["address"], () => {
@@ -72,7 +73,7 @@ function discover(cb,IPv4Interface = undefined) {
         });
 
         dsock.on("message", function(msg) {
-            if(msg.readUInt16LE(0) == 0x0063) { //Got em! Caught an Ethernet/IP response.
+            if(msg.readUInt16LE(0) == 0x0063) { //Got em! Caught a listIdentity response.
                 const enipPort = msg.readUInt16BE(34);
                 const ipString = msg.readUInt8(36).toString()+
                 "."+msg.readUInt8(37).toString()+
@@ -85,4 +86,106 @@ function discover(cb,IPv4Interface = undefined) {
     setTimeout(cb, 100, ENIPList);
 }
 
-module.exports = { promiseTimeout, delay, discover };
+/**
+ * Sends a broadcast to a specified IPv4 Interface in order to discover all present EthernetIP
+ * devices.
+ *
+ * @param {string} ipInterface - The interface the broadcast is sent to
+ * @returns {Promise}
+ * @memberof Utilities
+ */
+function getENIPDevicesProm(ipInterface){
+    return new Promise((resolve,reject)=>{
+        const ENIPList = new Array();
+        let dsock = dgram.createSocket("udp4");
+
+        let timeoutHandle = null;
+        dsock.bind(0,ipInterface["address"], () => {
+            dsock.setBroadcast(true);
+            const { listIdentity } = encapsulation;
+            
+            dsock.send(listIdentity(),44818,"255.255.255.255", (err) => {
+                if (err) throw new Error ("Error when sending via UDP: "+err);
+            });
+
+            // Resolve after 100 milliseconds
+            timeoutHandle = setTimeout(()=>{
+                resolve(ENIPList);
+            },100);           
+        });
+
+        dsock.on("error", function(err) {
+            console.log("UDP Error caught: " + err.stack);
+            if(timeoutHandle !== null){
+                clearTimeout(timeoutHandle);
+            }
+            reject(err);
+        });
+
+        dsock.on("message", function(msg) {
+            if(msg.readUInt16LE(0) == 0x0063) { //Got em! Caught a listIdentity response.
+                const enipPort = msg.readUInt16BE(34);
+                const ipString = msg.readUInt8(36).toString()+
+                "."+msg.readUInt8(37).toString()+
+                "."+msg.readUInt8(38).toString()+
+                "."+msg.readUInt8(39).toString(); 
+                ENIPList.push({port:enipPort,ip:ipString});
+            }
+        });
+        dsock.on("close", function() {
+            //console.log("TMP: On close");
+        });
+
+        dsock.on("listening", function() {
+            //console.log("TMP: On listening");
+        });
+    });
+}
+
+/**
+ * Sends a broadcast to a specified IPv4 Interface in order to discover all present EthernetIP
+ * devices. If no interface is specified, checks all available interfaces and sends a broadcast to them.
+ *
+ * @param {string} IPv4Interface - The interface we want to check the PLCs of, if not specified, all interfaces will be checked
+ * @returns {Promise} 
+ * @memberof Utilities
+ */
+async function discoverProm(IPv4Interface = undefined) {
+    const ENIPDeviceList = new Array();
+    const IPv4List = new Array();
+
+    /* No specified interface means we need to discover them on our own */
+    if(IPv4Interface == undefined) {
+        const interfaceList = os.networkInterfaces();
+        const iFaceListKeys = Object.keys(interfaceList);
+        const iFaceListLen = iFaceListKeys.length;
+        for (let i = 0; i < iFaceListLen; i += 1) {
+            let interfaces = interfaceList[iFaceListKeys[i]];
+            for (const addresses of interfaces) {
+                if(addresses["family"] == "IPv4") {
+                    IPv4List.push(addresses);
+                }
+            }
+        }
+    }
+    /* An interface has been specified! */
+    else {
+        const IPv4RegEx = new RegExp("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$");
+        if (!IPv4RegEx.test(IPv4Interface)) throw new Error("Interface must match IPv4 format!");
+        IPv4List.push({address: IPv4Interface});    
+    }
+
+    /* For each interface, we send a broadcast with a listIdentity command */
+    for (const addresses of IPv4List) {
+        const ENIPDevices = await getENIPDevicesProm(addresses); // Wait for an Interface to get all Devices
+        if (!Array.isArray(ENIPDevices) || !ENIPDevices.length) {
+            // No Devices returned
+        }
+        else {
+            ENIPDeviceList.push(ENIPDevices);
+        }
+    }
+    return ENIPDeviceList;
+}
+
+module.exports = { promiseTimeout, delay, discover, discoverProm };

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -1,3 +1,7 @@
+const os = require("os");
+const dgram = require("dgram");
+const encapsulation = require("../enip/encapsulation");
+
 /**
  * Wraps a Promise with a Timeout
  *
@@ -22,4 +26,86 @@ const promiseTimeout = (promise, ms, error = new Error("ASYNC Function Call Time
  */
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
-module.exports = { promiseTimeout, delay };
+/**
+ * Sends a broadcast to a specified IPv4 Interface in order to discover all present EthernetIP
+ * devices. If no interface is specified, checks all available interfaces and sends a broadcast to them.
+ *
+ * @override
+ * @param {string} IPv4Interface - The interface we want to check the PLCs of, if not specified, all interfaces will be checked
+ * @param {function} cb - The callback that is to be executed after the search is finished
+ * @returns {Promise}
+ * @memberof ENIP
+ */
+function discover(cb,IPv4Interface = undefined) {
+    const ENIPList = new Array();
+    if(IPv4Interface == undefined) {
+        const IPv4List = new Array();
+        const interfaceList = os.networkInterfaces();
+        const iFaceListKeys = Object.keys(interfaceList);
+        const iFaceListLen = iFaceListKeys.length;
+        for (let i = 0; i < iFaceListLen; i += 1) {
+            let interfaces = interfaceList[iFaceListKeys[i]];
+            for (const addresses of interfaces) {
+                if(addresses["family"] == "IPv4") {
+                    IPv4List.push(addresses);
+                }
+            }
+        }
+        for (const addresses of IPv4List) {
+            let dsock = dgram.createSocket("udp4");
+            dsock.bind(0,addresses["address"], () => {
+                dsock.setBroadcast(true);
+                const { listIdentity } = encapsulation;
+                dsock.send(listIdentity(),44818,"255.255.255.255", (err) => {
+                    if (err) throw new Error ("Error when sending via UDP: "+err);
+                });
+            });
+
+            dsock.on("error", function(err) {
+                console.log("UDP Error caught: " + err.stack);
+            });
+
+            dsock.on("message", function(msg) {
+                if(msg.readUInt16LE(0) == 0x0063) { //Got em! Caught an Ethernet/IP response.
+                    const enipPort = msg.readUInt16BE(34);
+                    const ipString = msg.readUInt8(36).toString()+
+                    "."+msg.readUInt8(37).toString()+
+                    "."+msg.readUInt8(38).toString()+
+                    "."+msg.readUInt8(39).toString(); 
+                    ENIPList.push({port:enipPort,ip:ipString});
+                }
+            });
+        }
+    }
+    else {
+        const IPv4RegEx = new RegExp("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$");
+        if (!IPv4RegEx.test(IPv4Interface)) throw new Error("Interface must match IPv4 format!");
+        let dsock = dgram.createSocket("udp4");
+        dsock.bind(0,IPv4Interface, () => {
+            dsock.setBroadcast(true);
+            const { listIdentity } = encapsulation;
+            dsock.send(listIdentity(),44818,"255.255.255.255", (err) => {
+                if (err) throw new Error ("Error when sending via UDP: "+err);
+            });
+        });
+
+        dsock.on("error", function(err) {
+            console.log("UDP Error caught: " + err.stack);
+        });
+
+        dsock.on("message", function(msg) {
+            if(msg.readUInt16LE(0) == 0x0063) { //Got em! Caught an Ethernet/IP response.
+                const enipPort = msg.readUInt16BE(34);
+                const ipString = msg.readUInt8(36).toString()+
+                "."+msg.readUInt8(37).toString()+
+                "."+msg.readUInt8(38).toString()+
+                "."+msg.readUInt8(39).toString(); 
+                ENIPList.push({port:enipPort,ip:ipString});
+            }
+        });
+    }
+      
+    setTimeout(cb, 1500, ENIPList);
+}
+
+module.exports = { promiseTimeout, delay, discover };


### PR DESCRIPTION
Hi, this PR aims at utilizing the ENIP-side of the communication to provide nice QoL features like retrieving asset-data via EtherNet/IP or discovering several devices

### Description, Motivation, and Context
The EtherNet/IP features of this library are well separated, which means we can also add more support here.

## How Has This Been Tested?
The ListIdentity / ListServices commands have been tested several times on a live PLC.
Same with discovery. I'd like some feedback on how much information the discovery reply should contain. Only IP/Port/Slot? Or the whole listIdentity response?

## Screenshots (if appropriate):
![img](https://i.imgur.com/m3vCYRv.png)

New Style of return:

![img2](https://i.imgur.com/AFyXaFy.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation. (Maybe an addition that we can discover enip-capable devices)
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] This is a work in progress, and I want some feedback (If yes, please mark it in the title -> e.g. `[WIP] Some awesome PR title`)