### PR TITLE
Support for Reading/Writing to Generic CIP Objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Ignore Local Script Folder
 /scripts
+
+# Ignore local test
+/src/maintest.js 

--- a/src/enip/cip/message-router/index.js
+++ b/src/enip/cip/message-router/index.js
@@ -8,6 +8,7 @@ const services = {
     DELETE: 0x09,
     MULTIPLE_SERVICE_PACKET: 0x0a,
     APPLY_ATTRIBUTES: 0x0d,
+    SET_ATTRIBUTE_ALL: 0x02,
     SET_ATTRIBUTE_SINGLE: 0x10,
     FIND_NEXT: 0x11,
     READ_TAG: 0x4c,

--- a/src/index.js
+++ b/src/index.js
@@ -4,4 +4,12 @@ const TagGroup = require("./tag-group");
 const EthernetIP = require("./enip");
 const util = require("./utilities");
 
+const PLC = new Controller();
+PLC.connect("192.168.1.11",0).then(async () => {
+    var x = await PLC.writeGenericSingle(0xF5,0x01,0x06,Buffer([0x05,0x00,0x12,0x23,0x34,0x00]));
+    console.log(x);
+    x = await PLC.readGenericSingle(0xF5,0x01,0x06);
+    console.log(x);
+});
+
 module.exports = { Controller, Tag, TagGroup, EthernetIP, util };

--- a/src/index.js
+++ b/src/index.js
@@ -4,14 +4,4 @@ const TagGroup = require("./tag-group");
 const EthernetIP = require("./enip");
 const util = require("./utilities");
 
-const PLC = new Controller();
-PLC.connect("192.168.1.11",0).then(async () => {
-    var x = await PLC.writeGenericSingle(0xF5,0x01,0x06,Buffer([0x05,0x00,0x12,0x23,0x34,0x00]));
-    console.log(x);
-    x = await PLC.readGenericSingle(0xF5,0x01,0x06);
-    console.log(x);
-    x = await PLC.readGenericAll(0xF5,0x01);
-    console.log(x);
-});
-
 module.exports = { Controller, Tag, TagGroup, EthernetIP, util };

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,8 @@ PLC.connect("192.168.1.11",0).then(async () => {
     console.log(x);
     x = await PLC.readGenericSingle(0xF5,0x01,0x06);
     console.log(x);
+    x = await PLC.readGenericAll(0xF5,0x01);
+    console.log(x);
 });
 
 module.exports = { Controller, Tag, TagGroup, EthernetIP, util };


### PR DESCRIPTION
This PR aims at using the inherent GET/SET_ATTRIBUTE(S)_SINGLE/ALL Service offered by CIP in order to allow accessing those objects by users

### Description, Motivation, and Context
We can extract more information by being able to access the entirety of the CIP object library

## How Has This Been Tested?
It is near-impossible to test the vast amount of available CIP Objects. I tested this on the TCP/IP Object and on the Identity Object of a RA-PLC.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation. - mainly additive, if we want to inform the users about this feature
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] This is a work in progress, and I want some feedback (If yes, please mark it in the title -> e.g. `[WIP] Some awesome PR title`)
