### PR TITLE
Fix for hanging timeout

### DIFF
--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -9,8 +9,11 @@
  */
 const promiseTimeout = (promise, ms, error = new Error("ASYNC Function Call Timed Out!!!")) => {
     return new Promise((resolve, reject) => {
-        setTimeout(() => reject(error), ms);
-        promise.then(resolve).catch(reject);
+        const timer = setTimeout(() => reject(error), ms);
+        promise.then(p => {
+            clearTimeout(timer);
+            resolve(p);
+        }).catch(reject);
     });
 };
 


### PR DESCRIPTION
When using methods from this library, there's a ~10 second delay before the process exits. It's due to the `setTimeout` in the `promiseTimeout` utility, which never gets cleared if the promise resolves successfully. Adding a `clearTimeout` here takes care of that.