### PR TITLE
[WIP] Add configuration option to unconnected send timeout

### DIFF
--- a/src/controller/controller.spec.js
+++ b/src/controller/controller.spec.js
@@ -54,5 +54,15 @@ describe("Controller Class", () => {
             const plc = new Controller({ queue_max_size: 200 });
             expect(plc.workers.read.max).toEqual(200);
         });
+
+        it("Default Unconnected Send timeout", () => {
+            const plc = new Controller();
+            expect(plc.params.unconnected_send_timeout).toEqual(2000);
+        });
+
+        it("Custom Unconnected Send timeout", () => {
+            const plc = new Controller({ unconnected_send_timeout: 5064 });
+            expect(plc.params.unconnected_send_timeout).toEqual(5064);
+        });
     });
 });

--- a/src/controller/index.js
+++ b/src/controller/index.js
@@ -11,7 +11,7 @@ const compare = (obj1, obj2) => {
 };
 
 class Controller extends ENIP {
-    constructor({ queue_max_size } = {}) {
+    constructor({ queue_max_size, unconnected_send_timeout = 2000 } = {}) {
         super();
         
         this.state = {
@@ -41,6 +41,8 @@ class Controller extends ENIP {
             write: new Queue(compare, queue_max_size),
             group: new Queue(compare, queue_max_size)
         };
+
+        this.params = { unconnected_send_timeout };
     }
 
     // region Property Definitions
@@ -143,7 +145,7 @@ class Controller extends ENIP {
     write_cip(data, connected = false, timeout = 10, cb = null) {
         const { UnconnectedSend } = CIP;
 
-        const msg = UnconnectedSend.build(data, this.state.controller.path);
+        const msg = UnconnectedSend.build(data, this.state.controller.path, this.params.unconnected_send_timeout);
 
         //TODO: Implement Connected Version
         super.write_cip(msg, connected, timeout, cb);

--- a/src/controller/index.js
+++ b/src/controller/index.js
@@ -11,6 +11,13 @@ const compare = (obj1, obj2) => {
 };
 
 class Controller extends ENIP {
+
+    /**
+     * 
+     * @param {object} [options] 
+     * @param {number} [options.queue_max_size=100] the maximum size for the command queue length
+     * @param {number} [options.unconnected_send_timeout=2000] the timeout value of messages of type "unconnected send"
+     */
     constructor({ queue_max_size, unconnected_send_timeout = 2000 } = {}) {
         super();
         


### PR DESCRIPTION

### Description, Motivation, and Context
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Implements changes as discussed in #67 to allow custom-setting the value of timeout on unconnected send messages

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with SoftLogix

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This is a work in progress, and I want some feedback (If yes, please mark it in the title -> e.g. `[WIP] Some awesome PR title`)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
 - #67 
 - [netsmarttech/node-red-contrib-cip-ethernet-ip#10](https://github.com/netsmarttech/node-red-contrib-cip-ethernet-ip/issues/10)
