### PR TITLE
debug 'buf' is not initialized

### DIFF
--- a/src/enip/cip/epath/segments/logical/index.js
+++ b/src/enip/cip/epath/segments/logical/index.js
@@ -61,10 +61,10 @@ const build = (type, address, padded = true) => {
         format = 2;
 
         if (padded) {
-            Buffer.alloc(6);
+            buf = Buffer.alloc(6);
             buf.writeUInt32LE(address, 2);
         } else {
-            Buffer.alloc(5);
+            buf = Buffer.alloc(5);
             buf.writeUInt32LE(address, 1);
         }
     }


### PR DESCRIPTION
debug 'buf' is not initialized.

*/node-ethernet-ip-master/src/enip/cip/epath/segments/logical/index.js:36
        throw new Error("Invalid Logical Type Code Passed to Segment Builder");
        ^

Error: Invalid Logical Type Code Passed to Segment Builder

small mistake.